### PR TITLE
Allow for an input folder relative to the vha file location

### DIFF
--- a/main-support.ts
+++ b/main-support.ts
@@ -76,6 +76,11 @@ export function countFoldersInFinalArray(imagesArray: ImageElement[]): number {
  * @param done          -- function to execute when done writing the file
  */
 export function writeVhaFileDangerously(finalObject: FinalObject, pathToTheFile: string, done): void {
+  // check for relative paths
+  if (finalObject.inputDir === path.parse(pathToTheFile).dir) {
+    finalObject.inputDir = "";
+  }
+
   const json = JSON.stringify(finalObject);
   // write the file
   fs.writeFile(pathToTheFile, json, 'utf8', done);

--- a/main.ts
+++ b/main.ts
@@ -246,17 +246,23 @@ function openThisDamnFile(pathToVhaFile: string) {
     } else {
       globals.currentlyOpenVhaFile = pathToVhaFile;
       lastSavedFinalObject = JSON.parse(data);
-      setGlobalsFromVhaFile(lastSavedFinalObject); // sets source folder ETC
 
       // path to folder where the VHA file is
       globals.selectedOutputFolder = path.parse(pathToVhaFile).dir;
+
+      // use relative paths
+      if (lastSavedFinalObject.inputDir === "") {
+        lastSavedFinalObject.inputDir = globals.selectedOutputFolder;
+      }
+
+      setGlobalsFromVhaFile(lastSavedFinalObject); // sets source folder ETC
 
       console.log(globals.selectedSourceFolder + ' - videos location');
       console.log(globals.selectedOutputFolder + ' - output location');
 
       globals.angularApp.sender.send(
         'finalObjectReturning',
-        JSON.parse(data),
+        lastSavedFinalObject,
         pathToVhaFile,
         globals.selectedOutputFolder + path.sep   // app needs the trailing slash (at least for now)
       );


### PR DESCRIPTION
This PR fixes #7, allowing for an input folder to be relative to the vha file location. This means you can move the whole library and vha file to a new location, and everything will still work! 😄

*Existing vha files will be updated when new files are added via a rescan.*

This is achieved when the input folder is set to an empty string in the vha file, which causes the input folder to be set to the same as the vha file parent folder.

When writing the vha file, if the input directory is the same as the vha file folder, the input directory will be set to an empty string!

In the future, it would be nice to add multiple input folders, and improve this logic if all input folders lie relative to the vha file! But for now, this just adds a little bit of functionality, and I assume most people leave the vha file with the input folder! 😄 