### PR TITLE
Replace fluent-ffmpeg with ffprobe exec command!

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -196,9 +196,6 @@ const shell = require('electron').shell;
 
 const ffprobePath = require('@ffprobe-installer/ffprobe').path.replace('app.asar', 'app.asar.unpacked');
 const ffmpegPath = require('@ffmpeg-installer/ffmpeg').path.replace('app.asar', 'app.asar.unpacked');
-const ffmpeg = require('fluent-ffmpeg');
-ffmpeg.setFfprobePath(ffprobePath);
-ffmpeg.setFfmpegPath(ffmpegPath);
 
 // ============================================================
 // My variables

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@ffmpeg-installer/ffmpeg": "1.0.17",
     "@ffprobe-installer/ffprobe": "1.0.9",
     "@ngx-translate/core": "11.0.1",
-    "angular2-virtual-scroll": "0.3.1",
+    "angular2-virtual-scroll": "0.3.1"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "0.11.3",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "@ffprobe-installer/ffprobe": "1.0.9",
     "@ngx-translate/core": "11.0.1",
     "angular2-virtual-scroll": "0.3.1",
-    "fluent-ffmpeg": "2.1.2"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "0.11.3",


### PR DESCRIPTION
Removed `fluent-ffmpeg` dependency, and replaced it with our own `exec` of `ffprobe`! 👍 

Fixes #25!