### PR TITLE
Folder-only view

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,7 @@
 	"recommendations": [
 		"angular.ng-template",
 		"coenraads.bracket-pair-colorizer",
+		"editorconfig.editorconfig",
 		"eg2.tslint"
 	]
 }

--- a/src/app/components/common/settings-buttons.ts
+++ b/src/app/components/common/settings-buttons.ts
@@ -22,6 +22,7 @@ export const SettingsButtonsGroups: string[][] = [
     'showThumbnails',
     'showFilmstrip',
     'showFiles',
+    'showFoldersOnly',
     'showClips',
   ],
   [
@@ -86,6 +87,13 @@ export let SettingsButtons: { [s: string]: SettingsButton } = {
     iconName: 'icon-show-filenames',
     title: 'BUTTONS.showFilesHint',
     description: 'BUTTONS.showFilesDescription',
+  },
+  'showFoldersOnly': {
+    hidden: false,
+    toggled: false,
+    iconName: 'icon-folder-blank',
+    title: 'BUTTONS.showFoldersOnlyHint',
+    description: 'BUTTONS.showFoldersOnlyDescription',
   },
   'showClips': {
     hidden: false,

--- a/src/app/components/home/file/file.component.html
+++ b/src/app/components/home/file/file.component.html
@@ -4,7 +4,7 @@
   @galleryItemAppear
 >
 
-  <div *ngIf="title === '*'; else fileNameBlock">
+  <div *ngIf="title === '***'; else fileNameBlock">
     <span class="icon icon-folder-blank"></span>
     <span
       [innerHtml]="folderPath | folderArrowsPipe : true"

--- a/src/app/components/home/file/file.component.ts
+++ b/src/app/components/home/file/file.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, HostListener } from '@angular/core';
+import { Component, Input } from '@angular/core';
 
 import { galleryItemAppear, metaAppear } from '../../common/animations';
 

--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -609,7 +609,9 @@
                 | wordFrequencyPipe: settingsButtons['showFreq'].toggled
                 | countPipe
                 | randomizePipe: shuffleTheViewNow
-                | folderViewPipe: (appState.currentView === 'files' && settingsButtons['showFolderInFileView'].toggled)"
+                | folderViewPipe: settingsButtons['showFoldersOnly'].toggled
+                                  || (appState.currentView === 'files' && settingsButtons['showFolderInFileView'].toggled)
+                                  : settingsButtons['showFoldersOnly'].toggled"
     >
 
     <!-- 24 above is 20 pixels for element and 4 for the fudge factor -->
@@ -669,8 +671,8 @@
           *ngFor="let item of scroll.viewPortItems"
           [folderPath]="item[0]"
           [title]="item[2]"
-          (click)="(item[2] === '*') ? handleFolderWordClicked(item[0]) : openVideo(item[3])"
-          (contextmenu)="(item[2] === '*') ? doNothing() : rightMouseClicked($event, item)"
+          (click)="(item[2] === '***') ? handleFolderWordClicked(item[0]) : openVideo(item[3])"
+          (contextmenu)="(item[2] === '***') ? doNothing() : rightMouseClicked($event, item)"
           [time]="item[4]"
           [rez]="item[5]"
           [fileSize]="item[7]"

--- a/src/app/components/home/home.component.ts
+++ b/src/app/components/home/home.component.ts
@@ -650,6 +650,9 @@ export class HomeComponent implements OnInit, AfterViewInit {
    * @param filter
    */
   handleFolderWordClicked(filter: string): void {
+    if (this.settingsButtons['showFoldersOnly']) {
+      this.toggleButton('showFiles'); // needed when we're in folder view
+    }
     this.showSidebar();
     if (!this.settingsButtons['folder'].toggled) {
       this.settingsButtons['folder'].toggled = true;
@@ -768,38 +771,48 @@ export class HomeComponent implements OnInit, AfterViewInit {
   }
 
   /**
+   * Toggles all views buttons off
+   * A helper function for `toggleBotton`
+   */
+  toggleAllViewsButtonsOff(): void {
+    this.settingsButtons['showClips'].toggled = false;
+    this.settingsButtons['showFiles'].toggled = false;
+    this.settingsButtons['showFilmstrip'].toggled = false;
+    this.settingsButtons['showFoldersOnly'].toggled = false;
+    this.settingsButtons['showThumbnails'].toggled = false;
+  }
+
+  /**
    * Perform appropriate action when a button is clicked
    * @param   uniqueKey   the uniqueKey string of the button
    */
   toggleButton(uniqueKey: string): void {
     if (uniqueKey === 'showThumbnails') {
+      this.toggleAllViewsButtonsOff();
       this.settingsButtons['showThumbnails'].toggled = true;
-      this.settingsButtons['showFilmstrip'].toggled = false;
-      this.settingsButtons['showFiles'].toggled = false;
-      this.settingsButtons['showClips'].toggled = false;
       this.appState.currentView = 'thumbs';
       this.computeTextBufferAmount();
       this.scrollToTop();
     } else if (uniqueKey === 'showFilmstrip') {
-      this.settingsButtons['showThumbnails'].toggled = false;
+      this.toggleAllViewsButtonsOff();
       this.settingsButtons['showFilmstrip'].toggled = true;
-      this.settingsButtons['showFiles'].toggled = false;
-      this.settingsButtons['showClips'].toggled = false;
       this.appState.currentView = 'filmstrip';
       this.computeTextBufferAmount();
       this.scrollToTop();
     } else if (uniqueKey === 'showFiles') {
-      this.settingsButtons['showThumbnails'].toggled = false;
-      this.settingsButtons['showFilmstrip'].toggled = false;
+      this.toggleAllViewsButtonsOff();
       this.settingsButtons['showFiles'].toggled = true;
-      this.settingsButtons['showClips'].toggled = false;
+      this.appState.currentView = 'files';
+      this.computeTextBufferAmount();
+      this.scrollToTop();
+    } else if (uniqueKey === 'showFoldersOnly') {
+      this.toggleAllViewsButtonsOff();
+      this.settingsButtons['showFoldersOnly'].toggled = true;
       this.appState.currentView = 'files';
       this.computeTextBufferAmount();
       this.scrollToTop();
     } else if (uniqueKey === 'showClips') {
-      this.settingsButtons['showThumbnails'].toggled = false;
-      this.settingsButtons['showFilmstrip'].toggled = false;
-      this.settingsButtons['showFiles'].toggled = false;
+      this.toggleAllViewsButtonsOff();
       this.settingsButtons['showClips'].toggled = true;
       this.appState.currentView = 'clips';
       this.computeTextBufferAmount();

--- a/src/app/components/pipes/folder-view.pipe.ts
+++ b/src/app/components/pipes/folder-view.pipe.ts
@@ -10,9 +10,10 @@ export class FolderViewPipe implements PipeTransform {
   /**
    * Inserts folders os elements for file view
    * @param finalArray
-   * @param render    whether to insert folders
+   * @param render      whether to insert folders
+   * @param folderOnly  whether to ONLY show folders
    */
-  transform(finalArray: any[], render: boolean): any[] {
+  transform(finalArray: any[], render: boolean, folderOnly: boolean): any[] {
     if (render) {
       const arrWithFolders = [];
 
@@ -23,12 +24,14 @@ export class FolderViewPipe implements PipeTransform {
           const tempClone = [];
           tempClone[0] = element[0];
           tempClone[1] = element[1];
-          tempClone[2] = '*'
+          tempClone[2] = '***';
 
           arrWithFolders.push(tempClone);
           previousFolder = element[0];
         }
-        arrWithFolders.push(element);
+        if (!folderOnly) {
+          arrWithFolders.push(element);
+        }
       });
 
       // console.log('folderViewPipe running');

--- a/src/app/i18n/en.ts
+++ b/src/app/i18n/en.ts
@@ -48,6 +48,8 @@ export const English = {
     showFilmstripHint: 'Show filmstrip',
     showFolderInFileViewDescription: 'Shows folder locations in the file view',
     showFolderInFileViewHint: 'Show folders in file view',
+    showFoldersOnlyDescription: 'Switches to the folders-only view',
+    showFoldersOnlyHint: 'Show folders only',
     showFreqDescription: 'Toggles the word cloud which shows up to nine of the most frequent words in currently shown files',
     showFreqHint: 'Word cloud',
     showMoreInfoDescription: 'Toggles showing file name, resolution, and video length',

--- a/src/app/i18n/ru.ts
+++ b/src/app/i18n/ru.ts
@@ -48,6 +48,8 @@ export const Russian = {
     showFilmstripHint: 'Показать киноленту',
     showFolderInFileViewDescription: 'Показывает расположение папок в представлении файла',
     showFolderInFileViewHint: 'Показать папки в представлении файла',
+    showFoldersOnlyDescription: 'Переключение на просмотр только по папкам',
+    showFoldersOnlyHint: 'Показывать только папки',
     showFreqDescription: 'Переключает облако слов, которое отображает до девяти наиболее часто встречающихся слов в отображаемых файлах',
     showFreqHint: 'Облако слов',
     showMoreInfoDescription: 'Переключает отображение имени файла, разрешения и длины видео',


### PR DESCRIPTION
This PR adds a new view to the app: *Folder-only view*

It will look like the file view, but will only show folders.
Clicking on the folder name should open the _file_ view showing all the files in that folder.