### PR TITLE
fix first run bug

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -336,7 +336,7 @@ ipc.on('just-started', function (event, someMessage) {
 
   fs.readFile(path.join(pathToAppData, 'video-hub-app', 'settings.json'), (err, data) => {
     if (err) {
-      event.sender.send('pleaseOpenWizard');
+      event.sender.send('pleaseOpenWizard', true); // firstRun = true!
     } else {
       event.sender.send('settingsReturning', JSON.parse(data), userWantedToOpen);
     }

--- a/src/app/components/home/home.component.ts
+++ b/src/app/components/home/home.component.ts
@@ -192,6 +192,8 @@ export class HomeComponent implements OnInit, AfterViewInit {
 
   // WIP
 
+  isFirstRunEver = false;
+
   currentLanguage: SupportedLanguage;
 
   // Listen for key presses
@@ -399,6 +401,11 @@ export class HomeComponent implements OnInit, AfterViewInit {
       this.progressPercent = a / b;
       this.progressString = 'loading - ' + Math.round(a * 100 / b) + '%';
       if (this.importStage === 2) {
+        if (this.isFirstRunEver) {
+          this.toggleButton('showThumbnails');
+          console.log('SHOULD FIX THE FIRST RUN BUG!!!');
+          this.isFirstRunEver = false;
+        }
         this.extractionPercent = Math.round(100 * a / b);
       }
       if (a === b) {
@@ -448,10 +455,13 @@ export class HomeComponent implements OnInit, AfterViewInit {
       }
     });
 
-    this.electronService.ipcRenderer.on('pleaseOpenWizard', (event) => {
+    this.electronService.ipcRenderer.on('pleaseOpenWizard', (event, firstRun) => {
       // Correlated with the first time ever starting the app !!!
       // Can happen when no settings present
       // Can happen when trying to open a .vha file that no longer exists
+      if (firstRun) {
+        this.firstRunLogic();
+      }
       this.showWizard = true;
       this.flickerReduceOverlay = false;
     });
@@ -486,7 +496,7 @@ export class HomeComponent implements OnInit, AfterViewInit {
     clearTimeout(this.myTimeout);
     this.myTimeout = setTimeout(() => {
       // console.log('Virtual scroll refreshed');
-      this.virtualScroller.refresh()
+      this.virtualScroller.refresh();
     }, delay);
   }
 
@@ -1268,7 +1278,7 @@ export class HomeComponent implements OnInit, AfterViewInit {
    * Change the language via ngx-translate
    * @param language
    */
-  changeLanguage(language: SupportedLanguage) {
+  changeLanguage(language: SupportedLanguage): void {
     this.currentLanguage = language;
     if (language === 'en') {
       this.translate.use('en');
@@ -1277,6 +1287,16 @@ export class HomeComponent implements OnInit, AfterViewInit {
       this.translate.use('ru');
       this.translate.setTranslation('ru', Russian );
     }
+  }
+
+  /**
+   * Run when user starts the app for the first time
+   * Gets triggered when the settings.json is missing from the app folder
+   */
+  firstRunLogic(): void {
+    console.log('WELCOME TO VIDEO HUB APP!');
+    console.log('this is the first time you are running this app');
+    this.isFirstRunEver = true;
   }
 
 }


### PR DESCRIPTION
*Problem:*
The first time users start the app and import a folder, the app opens to thumbnail view but shows no thumbnails.

*Solution:*
Thumbnails show up correctly after starting import when the app starts for the first time.

*Comments:*
This is a bit of dumb code, but it seems to work. I'm leaving the `firstRunLogic()` method (even though it currently just toggles one boolean) because in the future we may have some welcome message show up.

The app will think it's the first time it's running whenever the `settings.json` file is missing (one that keeps all app settings, one that is stored on hard disk). On windows it's located in `C:\Users\[USERNAME]\AppData\Roaming\video-hub-app`