### PR TITLE
4K filter now works

### DIFF
--- a/main-support.ts
+++ b/main-support.ts
@@ -17,7 +17,7 @@ import { globals } from './main-globals';
 export function labelVideo(width: number, height: number): string {
   let size = '';
   if (width === 3840 && height === 2160) {
-    size = '4k';
+    size = '4K';
   } else if (width === 1920 && height === 1080) {
     size = '1080';
   } else if (width === 1280 && height === 720) {

--- a/main-support.ts
+++ b/main-support.ts
@@ -4,6 +4,8 @@ const fs = require('fs');
 const hasher = require('crypto').createHash;
 
 import { FinalObject, ImageElement } from './src/app/components/common/final-object.interface';
+import { ResolutionString } from './src/app/components/pipes/resolution-filter.service';
+
 import { acceptableFiles } from './main-filenames';
 
 import { globals } from './main-globals';
@@ -15,7 +17,7 @@ import { globals } from './main-globals';
  * @param height
  */
 export function labelVideo(width: number, height: number): string {
-  let size = '';
+  let size: ResolutionString = '';
   if (width === 3840 && height === 2160) {
     size = '4K';
   } else if (width === 1920 && height === 1080) {

--- a/src/app/components/home/file/file.component.scss
+++ b/src/app/components/home/file/file.component.scss
@@ -21,6 +21,8 @@
 
 .size {
   left: 0;
+  text-align: right;
+  width: 21px;
 }
 
 .folder {

--- a/src/app/components/home/home.component.ts
+++ b/src/app/components/home/home.component.ts
@@ -1132,7 +1132,6 @@ export class HomeComponent implements OnInit, AfterViewInit {
   newResFilterSelected(selection: number[]): void {
     this.freqLeftBound = selection[0];
     this.freqRightBound = selection[1];
-    // console.log(selection);
   }
 
   clearLev(): void {

--- a/src/app/components/home/home.component.ts
+++ b/src/app/components/home/home.component.ts
@@ -4,7 +4,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { VirtualScrollerComponent } from 'ngx-virtual-scroller';
 
 import { ElectronService } from '../../providers/electron.service';
-import { ResolutionFilterService } from '../../components/pipes/resolution-filter.service';
+import { ResolutionFilterService, ResolutionString } from '../../components/pipes/resolution-filter.service';
 import { ShowLimitService } from '../../components/pipes/show-limit.service';
 import { TagsSaveService } from './tags/tags-save.service';
 import { WordFrequencyService } from '../../components/pipes/word-frequency.service';
@@ -134,7 +134,7 @@ export class HomeComponent implements OnInit, AfterViewInit {
   resolutionFreqArr: number[];
   freqLeftBound: number = 0;
   freqRightBound: number = 4;
-  resolutionNames: string[] = ['SD', '720', '1080', '4K'];
+  resolutionNames: ResolutionString[] = ['SD', '720', '1080', '4K'];
 
   rightClickShowing: boolean = false;
   itemToRename: any; // strongly type this -- it's an element from finalArray !!!

--- a/src/app/components/home/resfilter/resfilter.component.ts
+++ b/src/app/components/home/resfilter/resfilter.component.ts
@@ -1,4 +1,4 @@
-import { Component, HostListener, Input, OnDestroy, Output, EventEmitter } from '@angular/core';
+import { Component, Input, OnDestroy, Output, EventEmitter } from '@angular/core';
 
 @Component({
   selector: 'app-res-filter',

--- a/src/app/components/pipes/resolution-filter.pipe.ts
+++ b/src/app/components/pipes/resolution-filter.pipe.ts
@@ -1,6 +1,6 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
-import { ResolutionFilterService } from './resolution-filter.service';
+import { ResolutionFilterService, ResolutionString } from './resolution-filter.service';
 
 @Pipe({
   name: 'resolutionFilterPipe'
@@ -20,14 +20,14 @@ export class ResolutionFilterPipe implements PipeTransform {
     // console.log(this.resolutionMap);
   }
 
-  resolutionMap: Map<string, number> = new Map();
+  resolutionMap: Map<ResolutionString, number> = new Map();
 
   /**
    * Filter and show only videos that are within the resolution bounds
-   * @param finalArray 
-   * @param render 
-   * @param leftBound 
-   * @param rightBound 
+   * @param finalArray
+   * @param render
+   * @param leftBound
+   * @param rightBound
    */
   transform(finalArray: any, render?: boolean, leftBound?: number, rightBound?: number): any {
 

--- a/src/app/components/pipes/resolution-filter.service.ts
+++ b/src/app/components/pipes/resolution-filter.service.ts
@@ -2,6 +2,8 @@ import { Injectable } from '@angular/core';
 
 import { BehaviorSubject } from 'rxjs';
 
+export type ResolutionString = '' | 'SD' | '720' | '720+' | '1080' | '1080+' | '4K' | '4K+';
+
 @Injectable()
 export class ResolutionFilterService {
 
@@ -25,16 +27,16 @@ export class ResolutionFilterService {
    * Add each resolution to the map
    * @param resolution
    */
-  public addString(resolution: string): void {
+  public addString(resolution: ResolutionString): void {
     let result: string;
     if (resolution === '') {
-      result = 'SD'
+      result = 'SD';
     } else if (resolution === '720' || resolution === '720+') {
-      result = '720'
+      result = '720';
     } else if (resolution === '1080' || resolution === '1080+') {
-      result = '1080'
+      result = '1080';
     } else if (resolution === '4K' || resolution === '4K+') {
-      result = '4K'
+      result = '4K';
     }
     this.addResolution(result);
   }


### PR DESCRIPTION
4K filter didn't work because it was looking for `4K` not `4k` (capitalization matters).

Future `.vha` files will have correct string when extracting.

Fix includes strongly typing `resolutiongString` everywhere in the app 👍 

bonus: resolution in _file-view_ now aligned right (prettier)