### PR TITLE
Fix tag replace regex to only replace full words!

### DIFF
--- a/src/app/components/home/tags/tags.service.ts
+++ b/src/app/components/home/tags/tags.service.ts
@@ -80,7 +80,7 @@ export class TagsService {
    */
   private storeFinalArrayInMemory(finalArray: ImageElement[]): void {
     // Strip out: {}()[] as well as 'for', 'her', 'the', 'and', '-', & ','
-    const regex = /{|}|\(|\)|\[|\]|for|her|the|and|,|-/gi;
+    const regex = /{|}|\(|\)|\[|\]|\b(for|her|the|and)\b|,|-/gi;
 
     finalArray.forEach((element) => {
       const cleanedFileName: string = element.cleanName.toLowerCase().replace(regex, '');

--- a/src/app/components/pipes/word-frequency.service.ts
+++ b/src/app/components/pipes/word-frequency.service.ts
@@ -31,7 +31,7 @@ export class WordFrequencyService {
    */
   public addString(filename: string): void {
     // Strip out: {}()[] as well as 'for', 'her', 'the', 'and', & ','
-    const regex = /{|}|\(|\)|\[|\]|for|her|the|and|,/gi;
+    const regex = /{|}|\(|\)|\[|\]|\b(for|her|the|and)\b|,/gi;
     filename = filename.replace(regex, '');
     const wordArray = filename.split(' ');
     wordArray.forEach(word => {


### PR DESCRIPTION
Small PR to make it so that the tag replacement regex only replaces full words:

Example String: "my name is **the**o **and** this is **and**rew"

Previously: "my name is o this is rew"
_Strips out "the" and "and" everywhere_

Now: "my name is **the**o this is **and**rew"
_Only strips out the "and" when it's a full word"_