### PR TITLE
Add support for importing new files, and verifying thumbnails!

### DIFF
--- a/main-support.ts
+++ b/main-support.ts
@@ -614,6 +614,50 @@ export function hashFile(fileName: string, fileSize: string): string {
   return hash;
 }
 
+
+/**
+ * Figures out what new files there are,
+ * adds them to the finalArray,
+ * and calls `extractAllMetadata`
+ * (which will then send file home and start extracting images)
+ * @param angularFinalArray       -- array of ImageElements from Angular - most current view
+ * @param hdFinalArray            -- array of ImageElements from current hard drive scan
+ * @param inputFolder             -- the input folder (where videos are)
+ * @param numberOfScreenshots     -- the number of screenshots per video
+ * @param extractMetadataCallback -- function for extractAllMetadata to call when done
+ */
+export function findAndImportNewFiles(
+  angularFinalArray: ImageElement[],
+  hdFinalArray: ImageElement[],
+  inputFolder: string,
+  numberOfScreenshots: number,
+  extractMetadataCallback
+): void {
+
+  // Generate ImageElement[] of all the new elements to be added
+  const onlyNewElements: ImageElement[] =
+    findAllNewFiles(angularFinalArray, hdFinalArray, inputFolder);
+
+  // If there are new files
+  if (onlyNewElements.length > 0) {
+
+    const metaRescanStartIndex = angularFinalArray.length;
+    const finalArrayUpdated = angularFinalArray.concat(onlyNewElements);
+
+    extractAllMetadata(
+      finalArrayUpdated,
+      inputFolder,
+      numberOfScreenshots,
+      metaRescanStartIndex,
+      extractMetadataCallback // actually = sendFinalResultHome
+    );
+
+  } else {
+    sendCurrentProgress(1, 1, 0); // indicates 100%
+  }
+
+}
+
 /**
  * Figures out what new files there are,
  * adds them to the finalArray,
@@ -646,7 +690,7 @@ export function updateFinalArrayWithHD(
   const allDeletedRemoved: ImageElement[] =
     finalArrayWithoutDeleted(angularFinalArray, hdFinalArray, inputFolder, folderToDeleteFrom);
 
-  // If there are new ifles OR if any files have been deleted !!!
+  // If there are new files OR if any files have been deleted !!!
   if (onlyNewElements.length > 0 || allDeletedRemoved.length < angularFinalArray.length) {
 
     const metaRescanStartIndex = allDeletedRemoved.length;

--- a/main.ts
+++ b/main.ts
@@ -181,7 +181,8 @@ import {
   sendCurrentProgress,
   generateScreenshotStrip,
   updateFinalArrayWithHD,
-  writeVhaFileToDisk
+  writeVhaFileToDisk,
+  findAndImportNewFiles
 } from './main-support';
 
 import { FinalObject, ImageElement } from './src/app/components/common/final-object.interface';
@@ -408,6 +409,26 @@ ipc.on('choose-output', function (event, someMessage) {
 });
 
 /**
+ * Initiate scanning for new files and importing them
+ * now receives the finalArray from `home.component`
+ * because the user may have renamed files from within the app!
+ */
+ipc.on('import-new-files', function (event, currentAngularFinalArray: ImageElement[]) {
+  const currentVideoFolder = globals.selectedSourceFolder;
+  globals.cancelCurrentImport = false;
+  scanForNewFiles(currentAngularFinalArray, currentVideoFolder);
+});
+
+/**
+ * Initiate verifying all files have thumbnails
+ */
+ipc.on('verify-thumbnails', function (event) {
+  const currentVideoFolder = globals.selectedSourceFolder;
+  globals.cancelCurrentImport = false;
+  verifyThumbnails();
+});
+
+/**
  * Initiate rescan of the directory NEW
  * now receives the finalArray from `home.component`
  * because the user may have renamed files from within the app!
@@ -511,6 +532,56 @@ ipc.on('start-the-import', function (event, options: ImportSettingsObject) {
   }
 
 });
+
+/**
+ * Begin scanning for new files and importing them
+ *
+ * @param angularFinalArray  ImageElment[] from Angular (might have renamed files)
+ */
+function scanForNewFiles(angularFinalArray: ImageElement[], currentVideoFolder: string) {
+
+  // rescan the source directory
+  if (fs.existsSync(currentVideoFolder)) {
+    let videosOnHD: ImageElement[] = getVideoPathsAndNames(currentVideoFolder);
+
+    if (demo) {
+      videosOnHD = videosOnHD.slice(0, 50);
+    }
+
+    findAndImportNewFiles(
+      angularFinalArray,
+      videosOnHD,
+      currentVideoFolder,
+      globals.numberOfScreenshots,
+      sendFinalResultHome           // callback for when `extractAllMetadata` is called
+    );
+
+  } else {
+    sendCurrentProgress(1, 1, 0);
+    dialog.showMessageBox({
+      message: 'Directory ' + currentVideoFolder + ' does not exist',
+      buttons: ['OK']
+    });
+  }
+}
+
+/**
+ * Scan for missing thumbnails and generate them
+ */
+function verifyThumbnails() {
+  // resume extracting any missing thumbnails
+  const screenshotOutputFolder: string = path.join(globals.selectedOutputFolder, 'vha-' + globals.hubName);
+
+  const indexesToScan: number[] = missingThumbsIndex(lastSavedFinalObject.images, screenshotOutputFolder);
+
+  extractAllScreenshots(
+    lastSavedFinalObject.images,
+    globals.selectedSourceFolder,
+    screenshotOutputFolder,
+    globals.screenShotHeight,
+    indexesToScan
+  );
+}
 
 /**
  * Begins rescan procedure compared to what the app has currently

--- a/src/app/components/common/settings-buttons.ts
+++ b/src/app/components/common/settings-buttons.ts
@@ -49,6 +49,8 @@ export const SettingsButtonsGroups: string[][] = [
   [
     'resetSettings',
     'clearHistory',
+    'importNewFiles',
+    'verifyThumbnails',
     'rescanDirectory',
     'startWizard'
   ]
@@ -310,6 +312,21 @@ export let SettingsButtons: { [s: string]: SettingsButton } = {
     iconName: 'icon-checkmark', // this specific icon makes the setting only appear in All Settings (behind gear button)
     title: 'BUTTONS.resetSettingsHint',
     description: 'BUTTONS.resetSettingsDescription',
+  },
+  // TODO: Make these able to add to the button bar!
+  'importNewFiles': {
+    hidden: false,
+    toggled: false,
+    iconName: 'icon-checkmark', // this specific icon makes the setting only appear in All Settings (behind gear button)
+    title: 'BUTTONS.importNewFilesHint',
+    description: 'BUTTONS.importNewFilesDescription',
+  },
+  'verifyThumbnails': {
+    hidden: false,
+    toggled: false,
+    iconName: 'icon-checkmark', // this specific icon makes the setting only appear in All Settings (behind gear button)
+    title: 'BUTTONS.verifyThumbnailsHint',
+    description: 'BUTTONS.verifyThumbnailsDescription',
   },
   'rescanDirectory': {
     hidden: false,

--- a/src/app/components/home/home.component.ts
+++ b/src/app/components/home/home.component.ts
@@ -842,6 +842,10 @@ export class HomeComponent implements OnInit, AfterViewInit {
       this.clearRecentlyViewedHistory();
     } else if (uniqueKey === 'resetSettings') {
       this.resetSettingsToDefault();
+    } else if (uniqueKey === 'importNewFiles') {
+      this.importNewFiles();
+    } else if (uniqueKey === 'verifyThumbnails') {
+      this.verifyThumbnails();
     } else if (uniqueKey === 'rescanDirectory') {
       this.rescanDirectory();
     } else if (uniqueKey === 'shuffleGalleryNow') {
@@ -902,6 +906,28 @@ export class HomeComponent implements OnInit, AfterViewInit {
     this.screenshotSizeForImport = 200; // default
     this.toggleSettings();
     this.showWizard = true;
+  }
+
+  /**
+   * Scan for new files and import them
+   */
+  public importNewFiles(): void {
+    this.progressNum1 = 0;
+    this.importStage = 1;
+    this.toggleSettings();
+    console.log('scanning for new files');
+    this.electronService.ipcRenderer.send('import-new-files', this.finalArray);
+  }
+
+  /**
+   * Verify all files have thumbnails
+   */
+  public verifyThumbnails(): void {
+    this.progressNum1 = 0;
+    this.importStage = 2;
+    this.toggleSettings();
+    console.log('verifying thumbnails');
+    this.electronService.ipcRenderer.send('verify-thumbnails', this.finalArray);
   }
 
   /**

--- a/src/app/i18n/en.ts
+++ b/src/app/i18n/en.ts
@@ -35,8 +35,12 @@ export const English = {
     randomImageHint: 'Show random screenshot',
     randomizeGalleryDescription: 'Randomizes the order of video files after every search',
     randomizeGalleryHint: 'Randomize gallery order',
+    importNewFilesDescription: 'Quickly scan for new files only and import them',
+    importNewFilesHint: 'Import new files',
+    verifyThumbnailsDescription: 'Verify all files have thumbnails',
+    verifyThumbnailsHint: 'Verify thumbnails',
     // tslint:disable-next-line:max-line-length
-    rescanDirectoryDescription: 'Rescans the video folder for any file changes (addition, renaming, deletion of videos) and updates the current hub',
+    rescanDirectoryDescription: 'Rescan the video folder for any file changes (addition, renaming, deletion of videos) and update the current hub',
     rescanDirectoryHint: 'Rescan directory',
     resetSettingsDescription: 'Resets settings and buttons to their default values',
     resetSettingsHint: 'Reset settings',

--- a/src/app/i18n/ru.ts
+++ b/src/app/i18n/ru.ts
@@ -35,9 +35,14 @@ export const Russian = {
     randomImageHint: 'Показать случайный скриншот',
     randomizeGalleryDescription: 'Рандомизирует порядок видеофайлов после каждого поиска',
     randomizeGalleryHint: 'Рандомизировать порядок галереи',
+    // TODO: Translate these
+    importNewFilesDescription: 'Quickly scan for new files only and import them',
+    importNewFilesHint: 'Import new files',
+    verifyThumbnailsDescription: 'Verify all files have thumbnails',
+    verifyThumbnailsHint: 'Verify thumbnails',
     // tslint:disable-next-line:max-line-length
     rescanDirectoryDescription: 'Повторно сканирует папку видео для любых изменений файла (добавление, переименование, удаление видео) и обновляет текущий хаб',
-    rescanDirectoryHint: 'Rescan directory',
+    rescanDirectoryHint: 'Rescan directory', // <---- :)
     resetSettingsDescription: 'Сбрасывает настройки и кнопки к значениям по умолчанию',
     resetSettingsHint: 'Сброс настроек',
     resolutionFilterDescription: 'Переключает фильтр разрешения',


### PR DESCRIPTION
This PR is the start of #4 - it can be merged but I'm planning on refining it more on the UI side.

It adds support for finding and importing new files _only_, and also for verifying all files have thumbnails (resumable thumbnail importing).

I'm not happy with:
- The button labels: I'd prefer to have an action, and a description underneath. For example:
```
[] **Import New Files**
This will scan for new files only and import them, leaving current files alone.
```
- There's still no _full_ rescan option - I need to think if it's needed, or if the optimised rescan is enough!

- I'd like these function to be pinable to the button bar! (needs new icons)

- The strings need to be translated! 👍 