### PR TITLE
remove numberOfVidsIn method

### DIFF
--- a/main-support.ts
+++ b/main-support.ts
@@ -169,43 +169,6 @@ export function getVideoPathsAndNames(sourceFolderPath: string): ImageElement[] 
   return finalArray;
 }
 
-
-/**
- * Figure out and return the number of video files in a directory
- * @param folderPath path to folder to scan
- */
-export function numberOfVidsIn(folderPath: string): number {
-
-  let totalNumberOfFiles = 0;
-
-  // increases `totalNumberOfFiles` for every file found
-  const walkAndCountSync = (dir, filelist) => {
-    const files = fs.readdirSync(dir, {encoding: 'utf8', withFileTypes: true});
-
-    files.forEach(function (file) {
-      if (!fileSystemReserved(file.name)) {
-        try {
-          // if the item is a _DIRECTORY_
-          if (file.isDirectory()) {
-            filelist = walkAndCountSync(path.join(dir, file.name), filelist);
-          } else {
-            const extension = file.name.split('.').pop();
-            if (acceptableFiles.includes(extension.toLowerCase())) {
-              totalNumberOfFiles++;
-            }
-          }
-        } catch (err) {}
-      }
-    });
-
-    return filelist;
-  };
-
-  walkAndCountSync(folderPath, []);
-
-  return totalNumberOfFiles;
-}
-
 // -------------- SCAN IMAGES AND SAVE THEM !!! -----------------
 
 const ffprobePath = require('@ffprobe-installer/ffprobe').path.replace('app.asar', 'app.asar.unpacked');

--- a/main.ts
+++ b/main.ts
@@ -177,7 +177,6 @@ import {
   extractAllMetadata,
   getVideoPathsAndNames,
   missingThumbsIndex,
-  numberOfVidsIn,
   sendCurrentProgress,
   generateScreenshotStrip,
   updateFinalArrayWithHD,


### PR DESCRIPTION
🙇 Thank you to @cal2195 for the good cleanup & improvement in https://github.com/whyboris/Video-Hub-App/pull/58 -- we can now safely remove this method 🎉 

The method was basically a duplicate of `getVideoPathsAndNames` but it returned only the number of files. It was infinitesimally faster but the time 'savings' are not worth the repetition of code 👍 