### PR TITLE
Optimise output resolutions for scaling!

### DIFF
--- a/main-support.ts
+++ b/main-support.ts
@@ -221,8 +221,8 @@ export function generateScreenshotStrip(
   let allFramesFiltered = '';
   let outputFrames = '';
 
-  // Hardcode a specific ~16:9 ratio
-  const ssWidth: number = Math.ceil(screenshotHeight * 1.78);
+  // Hardcode a specific 16:9 ratio
+  const ssWidth: number = screenshotHeight * (16 / 9);
   // const ssPadWidth: number = ssWidth + 2;
   const ratioString: string = ssWidth + ':' + screenshotHeight;
   // const ratioPadString: string = ssPadWidth + ':' + screenshotHeight;

--- a/src/app/components/home/filmstrip/filmstrip.component.ts
+++ b/src/app/components/home/filmstrip/filmstrip.component.ts
@@ -42,7 +42,7 @@ export class FilmstripComponent implements OnInit {
 
   updateFilmXoffset($event) {
     if (this.hoverScrub) {
-      const imgWidth = this.imgHeight * 1.78; // 1.78 is the hardcoded aspect ratio
+      const imgWidth = this.imgHeight * (16 / 9); // hardcoded aspect ratio
       const containerWidth = this.filmstripHolder.nativeElement.getBoundingClientRect().width;
       const howManyScreensOutsideCutoff = (this.numOfScreenshots + 1) - Math.floor(containerWidth / imgWidth);
 

--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -913,13 +913,12 @@
       [disabled]="wizard.selectedOutputFolder === '' || wizard.selectedSourceFolder === '' || futureHubName === ''"
       class="size-dropdown languageDropDown"
     >
-      <option value="100">100px</option>
-      <option value="150">150px</option>
-      <option value="200" selected="selected">200px</option>
-      <option value="250">250px</option>
-      <option value="300">300px</option>
-      <option value="350">350px</option>
-      <option value="400">400px</option>
+      <option value="72">72p</option>
+      <option value="144">144p</option>
+      <option value="216">216p</option>
+      <option value="288" selected="selected">288p</option>
+      <option value="360">360p</option>
+      <option value="432">432p</option>
     </select>
 
     <span class="step-description">
@@ -930,7 +929,7 @@
       *ngIf="wizard.selectedOutputFolder !== ''"
       class="screenshot-preview"
       [ngStyle]="{
-          width: ((screenshotSizeForImport / 100) * 178) + 'px',
+          width: ((screenshotSizeForImport) * (16 / 9)) + 'px',
           height: screenshotSizeForImport + 'px'
         }"
       @galleryItemAppear

--- a/src/app/components/home/home.component.ts
+++ b/src/app/components/home/home.component.ts
@@ -968,7 +968,7 @@ export class HomeComponent implements OnInit, AfterViewInit {
    * Computes the preview width for thumbnails view
    */
   public computePreviewWidth(): void {
-    this.previewWidth = Math.ceil((this.imgHeight / 100) * 178);
+    this.previewWidth = this.imgHeight * (16 / 9);
   }
 
   /**


### PR DESCRIPTION
This PR fixes #67, switching to true 16:9 resolutions that are divisible by both 8 and 16, improving performance, fixing rounding issues/off by one pixel errors (as the width and heights are always whole numbers), and supporting more codecs.

I got the list of resolutions from here: https://pacoup.com/2011/06/12/list-of-true-169-resolutions/

Feel free to use different ones if you'd prefer, any of the divisible by 8 & 16 ones are good! 👍

We could also change the labels displayed to the user if they look too confusing, but keep the actual values!