### PR TITLE
Fix for corrupt metadata in files!

### DIFF
--- a/main-support.ts
+++ b/main-support.ts
@@ -550,10 +550,9 @@ function extractMetadataForThisONEFile(
     } else {
       const metadata = JSON.parse(data);
 
-      const streamDuration = metadata.streams[0].duration || Number.MAX_SAFE_INTEGER;
-      const metaDuration = metadata.format.duration || Number.MAX_SAFE_INTEGER;
+      const fileDuration = metadata.streams[0].duration || metadata.format.duration;
 
-      const duration = Math.round(Math.min(streamDuration, metaDuration)) || 0;
+      const duration = Math.round(fileDuration) || 0;
       const origWidth = metadata.streams[0].width;
       const origHeight = metadata.streams[0].height;
       const sizeLabel = labelVideo(origWidth, origHeight);

--- a/main-support.ts
+++ b/main-support.ts
@@ -549,7 +549,11 @@ function extractMetadataForThisONEFile(
       extractMetaCallback(imageElement);
     } else {
       const metadata = JSON.parse(data);
-      const duration = Math.round(metadata.format.duration) || 0;
+
+      const streamDuration = metadata.streams[0].duration || Number.MAX_SAFE_INTEGER;
+      const metaDuration = metadata.format.duration || Number.MAX_SAFE_INTEGER;
+
+      const duration = Math.round(Math.min(streamDuration, metaDuration)) || 0;
       const origWidth = metadata.streams[0].width;
       const origHeight = metadata.streams[0].height;
       const sizeLabel = labelVideo(origWidth, origHeight);


### PR DESCRIPTION
It appears in some files, the metadata for duration is longer than the actual streams themselves! 👎 This causes the thumbnail generation to fail as it tries to seek to timestamps that have no video!

This fix looks at both the metadata, and the stream duration, and chooses the shorter of the two! 👍 