### PR TITLE
Manual tags

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -16,8 +16,8 @@ import { HomeComponent } from './components/home/home.component';
 import { ManualTags } from './components/home/manual-tags/manual-tags.service';
 import { ResolutionFilterService } from './components/pipes/resolution-filter.service';
 import { ShowLimitService } from './components/pipes/show-limit.service';
-import { TagsSaveService } from './components/home/tags/tags-save.service';
-import { TagsService } from './components/home/tags/tags.service';
+import { AutoTagsSaveService } from './components/home/tags/tags-save.service';
+import { AutoTagsService } from './components/home/tags/tags.service';
 import { WordFrequencyService } from './components/pipes/word-frequency.service';
 
 import { AddTagComponent } from './components/home/manual-tags/add-tag.component';
@@ -101,8 +101,8 @@ import { WordFrequencyPipe } from './components/pipes/word-frequency.pipe';
     ResolutionFilterService,
     ShowLimitService,
     SimilarityService,
-    TagsSaveService,
-    TagsService,
+    AutoTagsSaveService,
+    AutoTagsService,
     WordFrequencyService
   ],
   bootstrap: [AppComponent]

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -5,18 +5,22 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
+import { AppRoutingModule } from './app-routing.module';
+
 import { TranslateModule } from '@ngx-translate/core';
 import { VirtualScrollerModule } from 'ngx-virtual-scroller';
 
 import { AlphabetPrefixService } from './components/pipes/alphabet-prefix.service';
 import { ElectronService } from './providers/electron.service';
 import { HomeComponent } from './components/home/home.component';
+import { ManualTags } from './components/home/manual-tags/manual-tags.service';
 import { ResolutionFilterService } from './components/pipes/resolution-filter.service';
 import { ShowLimitService } from './components/pipes/show-limit.service';
 import { TagsSaveService } from './components/home/tags/tags-save.service';
 import { TagsService } from './components/home/tags/tags.service';
 import { WordFrequencyService } from './components/pipes/word-frequency.service';
 
+import { AddTagComponent } from './components/home/manual-tags/add-tag.component';
 import { AppComponent } from './app.component';
 import { ClipComponent } from './components/home/clip/clip.component';
 import { DetailsComponent } from './components/home/details/details.component';
@@ -31,6 +35,7 @@ import { SliderFilterComponent } from './components/home/slider-filter/slider-fi
 import { StatisticsComponent } from './components/home/statistics/statistics.component';
 import { TagsComponent } from './components/home/tags/tags.component';
 import { TopComponent } from './components/home/top/top.component';
+import { ViewTagsComponent } from './components/home/manual-tags/view-tags.component';
 
 import { AlphabetPrefixPipe } from './components/pipes/alphabet-prefix.pipe';
 import { CountPipe } from './components/pipes/count.pipe';
@@ -47,10 +52,9 @@ import { TagFilterPipe } from './components/home/tags/tag-filter.pipe';
 import { TagMatchPipe } from './components/home/tags/tag-match.pipe';
 import { WordFrequencyPipe } from './components/pipes/word-frequency.pipe';
 
-import { AppRoutingModule } from './app-routing.module';
-
 @NgModule({
   declarations: [
+    AddTagComponent,
     AlphabetPrefixPipe,
     AppComponent,
     ClipComponent,
@@ -78,6 +82,7 @@ import { AppRoutingModule } from './app-routing.module';
     TagMatchPipe,
     TagsComponent,
     TopComponent,
+    ViewTagsComponent,
     WordFrequencyPipe
   ],
   imports: [
@@ -92,6 +97,7 @@ import { AppRoutingModule } from './app-routing.module';
     AlphabetPrefixService,
     ElectronService,
     FileSearchPipe,
+    ManualTags,
     ResolutionFilterService,
     ShowLimitService,
     SimilarityService,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -13,7 +13,7 @@ import { VirtualScrollerModule } from 'ngx-virtual-scroller';
 import { AlphabetPrefixService } from './components/pipes/alphabet-prefix.service';
 import { ElectronService } from './providers/electron.service';
 import { HomeComponent } from './components/home/home.component';
-import { ManualTags } from './components/home/manual-tags/manual-tags.service';
+import { ManualTagsService } from './components/home/manual-tags/manual-tags.service';
 import { ResolutionFilterService } from './components/pipes/resolution-filter.service';
 import { ShowLimitService } from './components/pipes/show-limit.service';
 import { AutoTagsSaveService } from './components/home/tags/tags-save.service';
@@ -97,7 +97,7 @@ import { WordFrequencyPipe } from './components/pipes/word-frequency.pipe';
     AlphabetPrefixService,
     ElectronService,
     FileSearchPipe,
-    ManualTags,
+    ManualTagsService,
     ResolutionFilterService,
     ShowLimitService,
     SimilarityService,

--- a/src/app/components/common/final-object.interface.ts
+++ b/src/app/components/common/final-object.interface.ts
@@ -16,6 +16,7 @@ export interface ImageElement {
   duration: number;              // duration of film as number
   fileName: string;              // for opening the file
   fileSize: number;              // file size in bytes
+  tags?: string[];               // tags associated with this particular file
   hash: string;                  // used for detecting changed files and as a screenshot identifier
   numOfScreenshots: number;      // number of screenshots for this file
   partialPath: string;           // for opening the file, just prepend the `inputDir`

--- a/src/app/components/home/details/details.component.html
+++ b/src/app/components/home/details/details.component.html
@@ -42,7 +42,7 @@
       {{ rez }}
     </span>
     <app-add-tag-component (tag)="addThisTag($event)"></app-add-tag-component>
-    <app-view-tags-component [tags]="tempTags"></app-view-tags-component>
+    <app-view-tags-component [tags]="tags"></app-view-tags-component>
   </div>
 
 </div>

--- a/src/app/components/home/details/details.component.html
+++ b/src/app/components/home/details/details.component.html
@@ -41,8 +41,17 @@
     <span class="fileSize">
       {{ rez }}
     </span>
-    <app-add-tag-component (tag)="addThisTag($event)"></app-add-tag-component>
-    <app-view-tags-component [tags]="tags"></app-view-tags-component>
+
+    <app-add-tag-component
+      (tag)="addThisTag($event)"
+    ></app-add-tag-component>
+
+    <app-view-tags-component
+      [tags]="tags"
+      [allowRemoval]="true"
+      (removeTagEmit)="removeThisTag($event)"
+    ></app-view-tags-component>
+
   </div>
 
 </div>

--- a/src/app/components/home/details/details.component.html
+++ b/src/app/components/home/details/details.component.html
@@ -41,6 +41,8 @@
     <span class="fileSize">
       {{ rez }}
     </span>
+    <app-add-tag-component (tag)="addThisTag($event)"></app-add-tag-component>
+    <app-view-tags-component [tags]="tempTags"></app-view-tags-component>
   </div>
 
 </div>

--- a/src/app/components/home/details/details.component.ts
+++ b/src/app/components/home/details/details.component.ts
@@ -29,6 +29,7 @@ export class DetailsComponent implements OnInit {
   @Input() folderPath: string;
   @Input() hoverScrub: boolean;
   @Input() hubName: string;
+  @Input() tags: string[];
   @Input() imgHeight: number;
   @Input() imgId: any; // the filename of screenshot strip without `.jpg`
   @Input() largerFont: boolean;
@@ -44,8 +45,6 @@ export class DetailsComponent implements OnInit {
   firstFilePath = '';
   fullFilePath = '';
   hover: boolean;
-
-  tempTags: string[] = ['one', 'two', 'three'];
 
   constructor(
     public tagService: ManualTags,
@@ -84,14 +83,12 @@ export class DetailsComponent implements OnInit {
   }
 
   addThisTag(tag: string) {
-    if (this.tempTags.includes(tag)) {
-      console.log('ALREADY ON THE LIST!');
+
+    if (this.tags.includes(tag)) {
+      console.log('TAG ALREADY ADDED!');
     } else {
-      this.tempTags.push(tag);
-      // also notify the service!
       this.tagService.addTag(tag);
 
-      // TODO: fix -- only emit if service returns succes !!!
       this.addTagToFinalArray.emit({
         id: this.imgId,
         tag: tag

--- a/src/app/components/home/details/details.component.ts
+++ b/src/app/components/home/details/details.component.ts
@@ -3,7 +3,6 @@ import { DomSanitizer } from '@angular/platform-browser';
 import { galleryItemAppear } from '../../common/animations';
 
 import { ManualTags } from '../manual-tags/manual-tags.service';
-import { add } from '@tweenjs/tween.js';
 
 export interface TagEmission {
   id: string;

--- a/src/app/components/home/details/details.component.ts
+++ b/src/app/components/home/details/details.component.ts
@@ -2,6 +2,8 @@ import { Component, Input, OnInit, ElementRef, ViewChild, Output, EventEmitter }
 import { DomSanitizer } from '@angular/platform-browser';
 import { galleryItemAppear } from '../../common/animations';
 
+import { ManualTags } from '../manual-tags/manual-tags.service';
+
 @Component({
   selector: 'app-details-item',
   templateUrl: './details.component.html',
@@ -40,6 +42,7 @@ export class DetailsComponent implements OnInit {
   tempTags: string[] = ['one', 'two', 'three'];
 
   constructor(
+    public tagService: ManualTags,
     public sanitizer: DomSanitizer
   ) { }
 
@@ -61,8 +64,8 @@ export class DetailsComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.firstFilePath = encodeURI('file://' + this.folderPath + '/' + 'vha-' + this.hubName + '/thumbnails/' + this.imgId + '.jpg');
-    this.fullFilePath =  encodeURI('file://' + this.folderPath + '/' + 'vha-' + this.hubName + '/filmstrips/' + this.imgId + '.jpg');
+    this.firstFilePath = 'file://' + this.folderPath + '/' + 'vha-' + this.hubName + '/thumbnails/' + this.imgId + '.jpg';
+    this.fullFilePath =  'file://' + this.folderPath + '/' + 'vha-' + this.hubName + '/filmstrips/' + this.imgId + '.jpg';
   }
 
   mouseIsMoving($event) {
@@ -75,9 +78,14 @@ export class DetailsComponent implements OnInit {
   }
 
   addThisTag(tag: string) {
-    console.log('received:');
-    console.log(tag);
-    this.tempTags.push(tag);
+    if (this.tempTags.includes(tag)) {
+      console.log('ALREADY ON THE LIST!');
+    } else {
+      this.tempTags.push(tag);
+      // also notify the service!
+      this.tagService.addTag(tag);
+    }
+
   }
 
 }

--- a/src/app/components/home/details/details.component.ts
+++ b/src/app/components/home/details/details.component.ts
@@ -4,6 +4,11 @@ import { galleryItemAppear } from '../../common/animations';
 
 import { ManualTags } from '../manual-tags/manual-tags.service';
 
+export interface TagEmission {
+  id: string;
+  tag: string;
+}
+
 @Component({
   selector: 'app-details-item',
   templateUrl: './details.component.html',
@@ -15,6 +20,7 @@ export class DetailsComponent implements OnInit {
   @ViewChild('filmstripHolder') filmstripHolder: ElementRef;
 
   @Output() openFileRequest = new EventEmitter<string>();
+  @Output() addTagToFinalArray = new EventEmitter<TagEmission>();
 
   @Input() darkMode: boolean;
   @Input() elHeight: number;
@@ -84,6 +90,12 @@ export class DetailsComponent implements OnInit {
       this.tempTags.push(tag);
       // also notify the service!
       this.tagService.addTag(tag);
+
+      // TODO: fix -- only emit if service returns succes !!!
+      this.addTagToFinalArray.emit({
+        id: this.imgId,
+        tag: tag
+      });
     }
 
   }

--- a/src/app/components/home/details/details.component.ts
+++ b/src/app/components/home/details/details.component.ts
@@ -2,7 +2,7 @@ import { Component, Input, OnInit, ElementRef, ViewChild, Output, EventEmitter }
 import { DomSanitizer } from '@angular/platform-browser';
 import { galleryItemAppear } from '../../common/animations';
 
-import { ManualTags } from '../manual-tags/manual-tags.service';
+import { ManualTagsService } from '../manual-tags/manual-tags.service';
 
 export interface TagEmission {
   id: string;
@@ -48,7 +48,7 @@ export class DetailsComponent implements OnInit {
   hover: boolean;
 
   constructor(
-    public tagService: ManualTags,
+    public tagService: ManualTagsService,
     public sanitizer: DomSanitizer
   ) { }
 

--- a/src/app/components/home/details/details.component.ts
+++ b/src/app/components/home/details/details.component.ts
@@ -3,10 +3,12 @@ import { DomSanitizer } from '@angular/platform-browser';
 import { galleryItemAppear } from '../../common/animations';
 
 import { ManualTags } from '../manual-tags/manual-tags.service';
+import { add } from '@tweenjs/tween.js';
 
 export interface TagEmission {
   id: string;
   tag: string;
+  type: 'add' | 'remove';
 }
 
 @Component({
@@ -20,7 +22,7 @@ export class DetailsComponent implements OnInit {
   @ViewChild('filmstripHolder') filmstripHolder: ElementRef;
 
   @Output() openFileRequest = new EventEmitter<string>();
-  @Output() addTagToFinalArray = new EventEmitter<TagEmission>();
+  @Output() editFinalArrayTag = new EventEmitter<TagEmission>();
 
   @Input() darkMode: boolean;
   @Input() elHeight: number;
@@ -83,18 +85,27 @@ export class DetailsComponent implements OnInit {
   }
 
   addThisTag(tag: string) {
-
     if (this.tags.includes(tag)) {
       console.log('TAG ALREADY ADDED!');
     } else {
       this.tagService.addTag(tag);
 
-      this.addTagToFinalArray.emit({
+      this.editFinalArrayTag.emit({
         id: this.imgId,
-        tag: tag
+        tag: tag,
+        type: 'add'
       });
     }
+  }
 
+  removeThisTag(tag: string) {
+    this.tagService.removeTag(tag);
+
+    this.editFinalArrayTag.emit({
+      id: this.imgId,
+      tag: tag,
+      type: 'remove'
+    });
   }
 
 }

--- a/src/app/components/home/details/details.component.ts
+++ b/src/app/components/home/details/details.component.ts
@@ -37,6 +37,8 @@ export class DetailsComponent implements OnInit {
   fullFilePath = '';
   hover: boolean;
 
+  tempTags: string[] = ['one', 'two', 'three'];
+
   constructor(
     public sanitizer: DomSanitizer
   ) { }
@@ -70,6 +72,12 @@ export class DetailsComponent implements OnInit {
 
       this.percentOffset = (100 / (this.numOfScreenshots - 1)) * Math.floor(cursorX / (containerWidth / this.numOfScreenshots));
     }
+  }
+
+  addThisTag(tag: string) {
+    console.log('received:');
+    console.log(tag);
+    this.tempTags.push(tag);
   }
 
 }

--- a/src/app/components/home/details/details.component.ts
+++ b/src/app/components/home/details/details.component.ts
@@ -84,7 +84,7 @@ export class DetailsComponent implements OnInit {
   }
 
   addThisTag(tag: string) {
-    if (this.tags.includes(tag)) {
+    if (this.tags && this.tags.includes(tag)) {
       console.log('TAG ALREADY ADDED!');
     } else {
       this.tagService.addTag(tag);

--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -825,7 +825,7 @@
           *ngFor="let item of scroll.viewPortItems"
           (contextmenu)="rightMouseClicked($event, item)"
           (openFileRequest)="openVideo($event)"
-          (addTagToFinalArray)="addTagToFile($event)"
+          (editFinalArrayTag)="editFinalArrayTag($event)"
           [elHeight]="imgHeight + textPaddingHeight"
           [elWidth]="previewWidth"
           [tags]="item.tags"

--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -825,6 +825,7 @@
           *ngFor="let item of scroll.viewPortItems"
           (contextmenu)="rightMouseClicked($event, item)"
           (openFileRequest)="openVideo($event)"
+          (addTagToFinalArray)="addTagToFile($event)"
           [elHeight]="imgHeight + textPaddingHeight"
           [elWidth]="previewWidth"
           [fileSize]="item.fileSize"

--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -828,6 +828,7 @@
           (addTagToFinalArray)="addTagToFile($event)"
           [elHeight]="imgHeight + textPaddingHeight"
           [elWidth]="previewWidth"
+          [tags]="item.tags"
           [fileSize]="item.fileSize"
           [folderPath]="appState.selectedOutputFolder"
           [hubName]="appState.hubName"

--- a/src/app/components/home/home.component.ts
+++ b/src/app/components/home/home.component.ts
@@ -1465,17 +1465,22 @@ export class HomeComponent implements OnInit, AfterViewInit {
 
   /**
    * Add tag to a particular file
-   * @param id - unique ID of the file (hash)
+   * @param emission - the type, tag, and uniqe ID of the file (hash)
    */
-  addTagToFile(emission: TagEmission): void {
+  editFinalArrayTag(emission: TagEmission): void {
     // console.log(emission);
 
     const position: number = this.fileMap.get(emission.id);
 
-    if (this.finalArray[position].tags) {
-      this.finalArray[position].tags.push(emission.tag);
+    if (emission.type === 'add') {
+      if (this.finalArray[position].tags) {
+        this.finalArray[position].tags.push(emission.tag);
+      } else {
+        this.finalArray[position].tags = [emission.tag];
+      }
     } else {
-      this.finalArray[position].tags = [emission.tag];
+      console.log('removing tag!');
+      this.finalArray[position].tags.splice(this.finalArray[position].tags.indexOf(emission.tag), 1);
     }
 
     // console.log(this.finalArray);

--- a/src/app/components/home/home.component.ts
+++ b/src/app/components/home/home.component.ts
@@ -3,10 +3,11 @@ import { Component, ChangeDetectorRef, OnInit, HostListener, ViewChild, ElementR
 import { TranslateService } from '@ngx-translate/core';
 import { VirtualScrollerComponent } from 'ngx-virtual-scroller';
 
+import { AutoTagsSaveService } from './tags/tags-save.service';
 import { ElectronService } from '../../providers/electron.service';
+import { ManualTags } from './manual-tags/manual-tags.service';
 import { ResolutionFilterService, ResolutionString } from '../../components/pipes/resolution-filter.service';
 import { ShowLimitService } from '../../components/pipes/show-limit.service';
-import { AutoTagsSaveService } from './tags/tags-save.service';
 import { WordFrequencyService } from '../../components/pipes/word-frequency.service';
 
 import { FinalObject, ImageElement } from '../common/final-object.interface';
@@ -14,6 +15,7 @@ import { HistoryItem } from '../common/history-item.interface';
 import { ImportSettingsObject } from '../common/import.interface';
 import { SavableProperties } from '../common/savable-properties.interface';
 import { SettingsObject } from '../common/settings-object.interface';
+import { TagEmission } from './details/details.component';
 import { WizardOptions } from '../common/wizard-options.interface';
 
 import { AppState, SupportedLanguage } from '../common/app-state';
@@ -37,7 +39,6 @@ import {
   slowFadeOut,
   topAnimation
 } from '../common/animations';
-import { TagEmission } from './details/details.component';
 
 // import { DemoContent } from '../../../assets/demo-content';
 
@@ -296,6 +297,7 @@ export class HomeComponent implements OnInit, AfterViewInit {
   constructor(
     public cd: ChangeDetectorRef,
     public electronService: ElectronService,
+    public manualTagsService: ManualTags,
     public resolutionFilterService: ResolutionFilterService,
     public showLimitService: ShowLimitService,
     public tagsSaveService: AutoTagsSaveService,
@@ -448,6 +450,7 @@ export class HomeComponent implements OnInit, AfterViewInit {
       this.updateVhaFileHistory(pathToFile, finalObject.inputDir, finalObject.hubName);
 
       this.setTags(finalObject.addTags, finalObject.removeTags);
+      this.manualTagsService.populateManualTags(finalObject.images);
 
       this.canCloseWizard = true;
       this.showWizard = false;

--- a/src/app/components/home/home.component.ts
+++ b/src/app/components/home/home.component.ts
@@ -5,7 +5,7 @@ import { VirtualScrollerComponent } from 'ngx-virtual-scroller';
 
 import { AutoTagsSaveService } from './tags/tags-save.service';
 import { ElectronService } from '../../providers/electron.service';
-import { ManualTags } from './manual-tags/manual-tags.service';
+import { ManualTagsService } from './manual-tags/manual-tags.service';
 import { ResolutionFilterService, ResolutionString } from '../../components/pipes/resolution-filter.service';
 import { ShowLimitService } from '../../components/pipes/show-limit.service';
 import { WordFrequencyService } from '../../components/pipes/word-frequency.service';
@@ -297,7 +297,7 @@ export class HomeComponent implements OnInit, AfterViewInit {
   constructor(
     public cd: ChangeDetectorRef,
     public electronService: ElectronService,
-    public manualTagsService: ManualTags,
+    public manualTagsService: ManualTagsService,
     public resolutionFilterService: ResolutionFilterService,
     public showLimitService: ShowLimitService,
     public tagsSaveService: AutoTagsSaveService,
@@ -450,7 +450,7 @@ export class HomeComponent implements OnInit, AfterViewInit {
       this.updateVhaFileHistory(pathToFile, finalObject.inputDir, finalObject.hubName);
 
       this.setTags(finalObject.addTags, finalObject.removeTags);
-      this.manualTagsService.populateManualTags(finalObject.images);
+      this.manualTagsService.populateManualTagsService(finalObject.images);
 
       this.canCloseWizard = true;
       this.showWizard = false;

--- a/src/app/components/home/manual-tags/add-tag.component.html
+++ b/src/app/components/home/manual-tags/add-tag.component.html
@@ -3,6 +3,7 @@
     #tagInputField
     class="inputFilter"
     (keyup.enter)="emitTag(currentText)"
+    (keyup.esc)="escape()"
     [(ngModel)]="currentText"
     (ngModelChange)="checkTypeahead($event)"
     (keydown.Tab)="tabPressed($event)"

--- a/src/app/components/home/manual-tags/add-tag.component.html
+++ b/src/app/components/home/manual-tags/add-tag.component.html
@@ -1,7 +1,15 @@
-<input
-  #myval
-  class="inputFilter"
-  (keyup.enter)="emitTag(myval.value)"
-  type="text"
-  placeholder="Add tag"
->
+<div class="intputContainer">
+  <input
+    #tagInputField
+    class="inputFilter"
+    (keyup.enter)="emitTag(currentText)"
+    [(ngModel)]="currentText"
+    (ngModelChange)="checkTypeahead($event)"
+    (keydown.Tab)="tabPressed($event)"
+    type="text"
+    placeholder="Add tag"
+  >
+  <span class="typeahead" *ngIf="typeAhead.length > 0">
+    {{ typeAhead }}
+  </span>
+</div>

--- a/src/app/components/home/manual-tags/add-tag.component.html
+++ b/src/app/components/home/manual-tags/add-tag.component.html
@@ -1,0 +1,7 @@
+<input
+  #myval
+  class="inputFilter"
+  (keyup.enter)="emitTag(myval.value)"
+  type="text"
+  placeholder="Add tag"
+>

--- a/src/app/components/home/manual-tags/add-tag.component.scss
+++ b/src/app/components/home/manual-tags/add-tag.component.scss
@@ -1,0 +1,19 @@
+@import './../variables';
+
+// TODO -- keep DRY -- this is taken from `inputFilter`
+.inputFilter {
+  border: 0;
+  border-bottom: 1px solid $gray-80;
+  background: transparent;
+  box-sizing: border-box;
+  font-size: 15px;
+  outline: none;
+  padding: 6px;
+  padding-bottom: 0;
+  margin: 5px 0 10px;
+  width: 140px;
+
+  &::placeholder {
+    color: $gray-80;
+  }
+}

--- a/src/app/components/home/manual-tags/add-tag.component.scss
+++ b/src/app/components/home/manual-tags/add-tag.component.scss
@@ -1,19 +1,34 @@
 @import './../variables';
 
+.intputContainer {
+  position: relative;
+}
+
 // TODO -- keep DRY -- this is taken from `inputFilter`
 .inputFilter {
-  border: 0;
-  border-bottom: 1px solid $gray-80;
   background: transparent;
+  border-color: $gray-80;
+  border-width: 0 0 1px;
   box-sizing: border-box;
   font-size: 15px;
-  outline: none;
-  padding: 6px;
-  padding-bottom: 0;
   margin: 5px 0 10px;
+  outline: none;
+  padding-bottom: 0;
+  padding: 6px;
+  position: absolute;
   width: 140px;
+  z-index: 2;
 
   &::placeholder {
     color: $gray-80;
   }
+}
+
+.typeahead {
+  color: $gray-60;
+  font-size: 15px;
+  left: 6px;
+  position:absolute;
+  top: 11px;
+  z-index: 1;
 }

--- a/src/app/components/home/manual-tags/add-tag.component.ts
+++ b/src/app/components/home/manual-tags/add-tag.component.ts
@@ -10,13 +10,29 @@ export class AddTagComponent {
 
   @Output() tag = new EventEmitter<string>();
 
+  currentText: string = '';
+  typeAhead: string = '';
+
   constructor(
     public tagService: ManualTags
   ) { }
 
   emitTag(text: string) {
-    console.log(text);
     this.tag.emit(text);
+    this.currentText = '';
+    this.typeAhead = '';
+
+  }
+
+  checkTypeahead(text: string) {
+    this.typeAhead = this.tagService.getTypeahead(text);
+  }
+
+  tabPressed($event): void {
+    if (this.typeAhead !== '') {
+      this.emitTag(this.typeAhead);
+      $event.preventDefault();
+    }
   }
 
 }

--- a/src/app/components/home/manual-tags/add-tag.component.ts
+++ b/src/app/components/home/manual-tags/add-tag.component.ts
@@ -1,4 +1,4 @@
-import { Component, Output, EventEmitter, Input } from '@angular/core';
+import { Component, Output, EventEmitter } from '@angular/core';
 import { ManualTags } from './manual-tags.service';
 
 @Component({

--- a/src/app/components/home/manual-tags/add-tag.component.ts
+++ b/src/app/components/home/manual-tags/add-tag.component.ts
@@ -1,5 +1,5 @@
 import { Component, Output, EventEmitter } from '@angular/core';
-import { ManualTags } from './manual-tags.service';
+import { ManualTagsService } from './manual-tags.service';
 
 @Component({
   selector: 'app-add-tag-component',
@@ -14,7 +14,7 @@ export class AddTagComponent {
   typeAhead: string = '';
 
   constructor(
-    public tagService: ManualTags
+    public tagService: ManualTagsService
   ) { }
 
   emitTag(text: string) {

--- a/src/app/components/home/manual-tags/add-tag.component.ts
+++ b/src/app/components/home/manual-tags/add-tag.component.ts
@@ -1,0 +1,22 @@
+import { Component, Output, EventEmitter } from '@angular/core';
+import { ManualTags } from './manual-tags.service';
+
+@Component({
+  selector: 'app-add-tag-component',
+  templateUrl: 'add-tag.component.html',
+  styleUrls: ['add-tag.component.scss']
+})
+export class AddTagComponent {
+
+  @Output() tag = new EventEmitter<string>();
+
+  constructor(
+    public tagService: ManualTags
+  ) { }
+
+  emitTag(text: string) {
+    console.log(text);
+    this.tag.emit(text);
+  }
+
+}

--- a/src/app/components/home/manual-tags/add-tag.component.ts
+++ b/src/app/components/home/manual-tags/add-tag.component.ts
@@ -1,4 +1,4 @@
-import { Component, Output, EventEmitter } from '@angular/core';
+import { Component, Output, EventEmitter, Input } from '@angular/core';
 import { ManualTags } from './manual-tags.service';
 
 @Component({
@@ -33,6 +33,14 @@ export class AddTagComponent {
       this.emitTag(this.typeAhead);
       $event.preventDefault();
     }
+  }
+
+  /**
+   * User pressed the `esc` key
+   */
+  escape(): void {
+    this.currentText = '';
+    this.typeAhead = '';
   }
 
 }

--- a/src/app/components/home/manual-tags/manual-tags.service.ts
+++ b/src/app/components/home/manual-tags/manual-tags.service.ts
@@ -24,6 +24,15 @@ export class ManualTags {
     }
   }
 
+  removeTag(tag: string): void {
+    const count = this.tagsMap.get(tag);
+    this.tagsMap.set(tag, count - 1);
+
+    if (count === 1) {
+      this.tagsList.splice(this.tagsList.indexOf(tag), 1);
+    }
+  }
+
   /**
    * Get the most likely tag
    * TODO -- curently it gets the FIRST match; later get the MOST COMMON (confer with tagsMap)

--- a/src/app/components/home/manual-tags/manual-tags.service.ts
+++ b/src/app/components/home/manual-tags/manual-tags.service.ts
@@ -3,6 +3,44 @@ import { Injectable } from '@angular/core';
 @Injectable()
 export class ManualTags {
 
+  tagsMap: Map<string, number> = new Map();
+  tagsList: string[] = [];
+
   constructor() { }
+
+  addTag(tag: string): void {
+    console.log('tag service:');
+
+    if (this.tagsMap.get(tag)) {
+      const count = this.tagsMap.get(tag);
+      this.tagsMap.set(tag, count + 1);
+    } else {
+      this.tagsMap.set(tag, 1);
+      this.tagsList.push(tag);
+    }
+
+    console.log(this.tagsMap);
+  }
+
+  /**
+   * Get the most likely tag
+   * TODO -- curently it gets the FIRST match; later get the MOST COMMON (confer with tagsMap)
+   * @param text
+   */
+  getTypeahead(text: string): string {
+
+    let mostLikely = '';
+
+    if (text) {
+      for (let i = 0; i < this.tagsList.length; i++) {
+        if (this.tagsList[i].startsWith(text)) {
+          mostLikely = this.tagsList[i];
+          break;
+        }
+      }
+    }
+
+    return mostLikely;
+  }
 
 }

--- a/src/app/components/home/manual-tags/manual-tags.service.ts
+++ b/src/app/components/home/manual-tags/manual-tags.service.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@angular/core';
 import { ImageElement } from '../../common/final-object.interface';
 
 @Injectable()
-export class ManualTags {
+export class ManualTagsService {
 
   tagsMap: Map<string, number> = new Map();
   tagsList: string[] = [];
@@ -58,7 +58,7 @@ export class ManualTags {
    * Generate the tagsList and tagsMap the first time a hub is opened
    * @param allFiles - ImageElement array
    */
-  populateManualTags(allFiles: ImageElement[]): void {
+  populateManualTagsService(allFiles: ImageElement[]): void {
     allFiles.forEach((element: ImageElement): void => {
       if (element.tags) {
         element.tags.forEach((tag: string): void => {

--- a/src/app/components/home/manual-tags/manual-tags.service.ts
+++ b/src/app/components/home/manual-tags/manual-tags.service.ts
@@ -60,9 +60,11 @@ export class ManualTags {
    */
   populateManualTags(allFiles: ImageElement[]): void {
     allFiles.forEach((element: ImageElement): void => {
-      element.tags.forEach((tag: string): void => {
-        this.addTag(tag);
-      });
+      if (element.tags) {
+        element.tags.forEach((tag: string): void => {
+          this.addTag(tag);
+        });
+      }
     });
 
     console.log('done populating manual tags:');

--- a/src/app/components/home/manual-tags/manual-tags.service.ts
+++ b/src/app/components/home/manual-tags/manual-tags.service.ts
@@ -1,5 +1,7 @@
 import { Injectable } from '@angular/core';
 
+import { ImageElement } from '../../common/final-object.interface';
+
 @Injectable()
 export class ManualTags {
 
@@ -8,9 +10,11 @@ export class ManualTags {
 
   constructor() { }
 
+  /**
+   * Update the tagsList & tagsMap with the tag
+   * @param tag - tag to be added
+   */
   addTag(tag: string): void {
-    console.log('tag service:');
-
     if (this.tagsMap.get(tag)) {
       const count = this.tagsMap.get(tag);
       this.tagsMap.set(tag, count + 1);
@@ -18,8 +22,6 @@ export class ManualTags {
       this.tagsMap.set(tag, 1);
       this.tagsList.push(tag);
     }
-
-    console.log(this.tagsMap);
   }
 
   /**
@@ -41,6 +43,22 @@ export class ManualTags {
     }
 
     return mostLikely;
+  }
+
+  /**
+   * Generate the tagsList and tagsMap the first time a hub is opened
+   * @param allFiles - ImageElement array
+   */
+  populateManualTags(allFiles: ImageElement[]): void {
+    allFiles.forEach((element: ImageElement): void => {
+      element.tags.forEach((tag: string): void => {
+        this.addTag(tag);
+      });
+    });
+
+    console.log('done populating manual tags:');
+    console.log(this.tagsList);
+    console.log(this.tagsMap);
   }
 
 }

--- a/src/app/components/home/manual-tags/manual-tags.service.ts
+++ b/src/app/components/home/manual-tags/manual-tags.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@angular/core';
+
+@Injectable()
+export class ManualTags {
+
+  constructor() { }
+
+}

--- a/src/app/components/home/manual-tags/view-tags.component.html
+++ b/src/app/components/home/manual-tags/view-tags.component.html
@@ -3,6 +3,9 @@
     *ngFor="let tag of tags; index as i"
     class="singleTag"
   >
+    <span class="coverTheX">
+      &ensp;
+    </span>
     <span
       class="tag"
     >

--- a/src/app/components/home/manual-tags/view-tags.component.html
+++ b/src/app/components/home/manual-tags/view-tags.component.html
@@ -1,0 +1,3 @@
+<div>
+  <span class="tag" *ngFor="let tag of tags; index as i">{{ tag }}</span>
+</div>

--- a/src/app/components/home/manual-tags/view-tags.component.html
+++ b/src/app/components/home/manual-tags/view-tags.component.html
@@ -1,15 +1,18 @@
 <div class="tagContainer">
-  <span
-    class="tag"
+  <div
     *ngFor="let tag of tags; index as i"
+    class="singleTag"
   >
-    {{ tag }}
-    <div
+    <span
+      class="tag"
+    >
+      {{ tag }}
+    </span>
+    <span
       *ngIf="allowRemoval"
-      class="removeTag"
+      class="icon icon-close removeTag"
       (click)="removeTag(tag)"
     >
-      x
-    </div>
-  </span>
+    </span>
+  </div>
 </div>

--- a/src/app/components/home/manual-tags/view-tags.component.html
+++ b/src/app/components/home/manual-tags/view-tags.component.html
@@ -1,3 +1,3 @@
-<div>
+<div class="tagContainer">
   <span class="tag" *ngFor="let tag of tags; index as i">{{ tag }}</span>
 </div>

--- a/src/app/components/home/manual-tags/view-tags.component.html
+++ b/src/app/components/home/manual-tags/view-tags.component.html
@@ -1,3 +1,15 @@
 <div class="tagContainer">
-  <span class="tag" *ngFor="let tag of tags; index as i">{{ tag }}</span>
+  <span
+    class="tag"
+    *ngFor="let tag of tags; index as i"
+  >
+    {{ tag }}
+    <div
+      *ngIf="allowRemoval"
+      class="removeTag"
+      (click)="removeTag(tag)"
+    >
+      x
+    </div>
+  </span>
 </div>

--- a/src/app/components/home/manual-tags/view-tags.component.scss
+++ b/src/app/components/home/manual-tags/view-tags.component.scss
@@ -1,20 +1,53 @@
-.tag {
-  // copied from `searchWord` class -- TODO - keep DRY
-  border-radius: 6px;
-  box-shadow: 1px 1px 3px 0px rgba(0,0,0,0.3);
-  background-color: #f1ceb8;
-  cursor: pointer;
-  display: inline-block;
-  font-size: 10px;
-  margin: 6px 6px 0 0;
-  padding: 2px 4px 2px 4px;
-}
-
 .tagContainer {
   margin-top: 50px;
 }
 
-.removeTag {
+.singleTag {
   display: inline-block;
-  cursor: not-allowed;
+  margin-right: 20px;
+  position: relative;
+
+  .tag {
+    // copied from `searchWord` class -- TODO - keep DRY
+    background-color: #f1ceb8;
+    border-radius: 6px;
+    box-shadow: 1px 1px 3px 0px rgba(0,0,0,0.3);
+    cursor: pointer;
+    display: inline-block;
+    font-size: 10px;
+    height: 12px;
+    margin: 0;
+    padding: 2px 4px;
+    position: relative;
+    z-index: 2;
+  }
+
+  .removeTag {
+    background-color: #d1ae98;
+    border-radius: 6px;
+    color: red;
+    cursor: not-allowed;
+    display: inline-block;
+    height: 16px;
+    padding-right: 3px;
+    position: absolute;
+    right: 0;
+    text-align: right;
+    top: 3px;
+    transform: translate(0, 0);
+    transition-delay: 0.25s;
+    transition-duration: 0.25s;
+    transition-property: transform;
+    width: 20px;
+    z-index: 1;
+  }
+
+  &:hover {
+    .removeTag {
+      transform: translate(14px, 0);
+      transition-delay: 0.5s;
+      transition-duration: 0.25s;
+      transition-property: transform;
+    }
+  }
 }

--- a/src/app/components/home/manual-tags/view-tags.component.scss
+++ b/src/app/components/home/manual-tags/view-tags.component.scss
@@ -13,3 +13,8 @@
 .tagContainer {
   margin-top: 50px;
 }
+
+.removeTag {
+  display: inline-block;
+  cursor: not-allowed;
+}

--- a/src/app/components/home/manual-tags/view-tags.component.scss
+++ b/src/app/components/home/manual-tags/view-tags.component.scss
@@ -11,5 +11,5 @@
 }
 
 .tagContainer {
-  margin-top: 40px;
+  margin-top: 50px;
 }

--- a/src/app/components/home/manual-tags/view-tags.component.scss
+++ b/src/app/components/home/manual-tags/view-tags.component.scss
@@ -1,3 +1,5 @@
+@import "../variables";
+
 .tagContainer {
   margin-top: 50px;
 }
@@ -10,7 +12,7 @@
   .tag {
     // copied from `searchWord` class -- TODO - keep DRY
     background-color: #f1ceb8;
-    border-radius: 6px;
+    border-radius: 4px;
     box-shadow: 1px 1px 3px 0px rgba(0,0,0,0.3);
     cursor: pointer;
     display: inline-block;
@@ -19,12 +21,21 @@
     margin: 0;
     padding: 2px 4px;
     position: relative;
+    z-index: 3;
+  }
+
+  .coverTheX {
+    background: $gray-40;
+    height: 22px;
+    position: absolute;
+    transform: translate(-6px, 0);
+    width: 12px;
     z-index: 2;
   }
 
   .removeTag {
     background-color: #d1ae98;
-    border-radius: 6px;
+    border-radius: 4px;
     color: red;
     cursor: not-allowed;
     display: inline-block;
@@ -38,13 +49,13 @@
     transition-delay: 0.25s;
     transition-duration: 0.25s;
     transition-property: transform;
-    width: 20px;
+    width: 16px;
     z-index: 1;
   }
 
   &:hover {
     .removeTag {
-      transform: translate(14px, 0);
+      transform: translate(12px, 0);
       transition-delay: 0.5s;
       transition-duration: 0.25s;
       transition-property: transform;

--- a/src/app/components/home/manual-tags/view-tags.component.scss
+++ b/src/app/components/home/manual-tags/view-tags.component.scss
@@ -9,3 +9,7 @@
   margin: 6px 6px 0 0;
   padding: 2px 4px 2px 4px;
 }
+
+.tagContainer {
+  margin-top: 40px;
+}

--- a/src/app/components/home/manual-tags/view-tags.component.scss
+++ b/src/app/components/home/manual-tags/view-tags.component.scss
@@ -1,0 +1,11 @@
+.tag {
+  // copied from `searchWord` class -- TODO - keep DRY
+  border-radius: 6px;
+  box-shadow: 1px 1px 3px 0px rgba(0,0,0,0.3);
+  background-color: #f1ceb8;
+  cursor: pointer;
+  display: inline-block;
+  font-size: 10px;
+  margin: 6px 6px 0 0;
+  padding: 2px 4px 2px 4px;
+}

--- a/src/app/components/home/manual-tags/view-tags.component.ts
+++ b/src/app/components/home/manual-tags/view-tags.component.ts
@@ -1,0 +1,17 @@
+import { Component, Input } from '@angular/core';
+import { ManualTags } from './manual-tags.service';
+
+@Component({
+  selector: 'app-view-tags-component',
+  templateUrl: 'view-tags.component.html',
+  styleUrls: ['view-tags.component.scss']
+})
+export class ViewTagsComponent {
+
+  @Input() tags: string[];
+
+  constructor(
+    public tagService: ManualTags
+  ) { }
+
+}

--- a/src/app/components/home/manual-tags/view-tags.component.ts
+++ b/src/app/components/home/manual-tags/view-tags.component.ts
@@ -4,7 +4,8 @@ import { ManualTags } from './manual-tags.service';
 @Component({
   selector: 'app-view-tags-component',
   templateUrl: 'view-tags.component.html',
-  styleUrls: ['view-tags.component.scss']
+  styleUrls: ['view-tags.component.scss',
+              '../fonts/icons.scss']
 })
 export class ViewTagsComponent {
 

--- a/src/app/components/home/manual-tags/view-tags.component.ts
+++ b/src/app/components/home/manual-tags/view-tags.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, Output, EventEmitter } from '@angular/core';
 import { ManualTags } from './manual-tags.service';
 
 @Component({
@@ -9,9 +9,17 @@ import { ManualTags } from './manual-tags.service';
 export class ViewTagsComponent {
 
   @Input() tags: string[];
+  @Input() allowRemoval: boolean;
+
+  @Output() removeTagEmit = new EventEmitter<string>();
 
   constructor(
     public tagService: ManualTags
   ) { }
+
+  removeTag(tag: string): void {
+    console.log('remove tag clicked');
+    this.removeTagEmit.emit(tag);
+  }
 
 }

--- a/src/app/components/home/manual-tags/view-tags.component.ts
+++ b/src/app/components/home/manual-tags/view-tags.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, Output, EventEmitter } from '@angular/core';
-import { ManualTags } from './manual-tags.service';
+import { ManualTagsService } from './manual-tags.service';
 
 @Component({
   selector: 'app-view-tags-component',
@@ -15,7 +15,7 @@ export class ViewTagsComponent {
   @Output() removeTagEmit = new EventEmitter<string>();
 
   constructor(
-    public tagService: ManualTags
+    public tagService: ManualTagsService
   ) { }
 
   removeTag(tag: string): void {

--- a/src/app/components/home/tags/tag-match.pipe.ts
+++ b/src/app/components/home/tags/tag-match.pipe.ts
@@ -1,6 +1,6 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
-import { TagsService } from './tags.service';
+import { AutoTagsService } from './tags.service';
 
 @Pipe({
   name: 'tagMatchPipe'
@@ -8,7 +8,7 @@ import { TagsService } from './tags.service';
 export class TagMatchPipe implements PipeTransform {
 
   constructor(
-    public tagsService: TagsService
+    public tagsService: AutoTagsService
   ) { }
 
   /**

--- a/src/app/components/home/tags/tags-save.service.ts
+++ b/src/app/components/home/tags/tags-save.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 
 @Injectable()
-export class TagsSaveService {
+export class AutoTagsSaveService {
 
   addTags: string[] = [];
   removeTags: string[] = [];

--- a/src/app/components/home/tags/tags.component.ts
+++ b/src/app/components/home/tags/tags.component.ts
@@ -1,7 +1,7 @@
 import { Component, EventEmitter, Input, Output, OnDestroy, ViewChild, ElementRef, OnInit } from '@angular/core';
 
-import { TagsService, WordAndFreq } from './tags.service';
-import { TagsSaveService } from './tags-save.service';
+import { AutoTagsService, WordAndFreq } from './tags.service';
+import { AutoTagsSaveService } from './tags-save.service';
 
 import { ImageElement } from '../../../components/common/final-object.interface';
 
@@ -39,8 +39,8 @@ export class TagsComponent implements OnInit, OnDestroy {
   showingStatusMessage: boolean = false;
 
   constructor(
-    public tagsService: TagsService,
-    public tagsSaveService: TagsSaveService
+    public tagsService: AutoTagsService,
+    public tagsSaveService: AutoTagsSaveService
   ) {}
 
   ngOnInit(): void {

--- a/src/app/components/home/tags/tags.service.ts
+++ b/src/app/components/home/tags/tags.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 
-import { TagsSaveService } from './tags-save.service';
+import { AutoTagsSaveService } from './tags-save.service';
 
 import { ImageElement } from '../../../components/common/final-object.interface';
 
@@ -10,7 +10,7 @@ export interface WordAndFreq {
 }
 
 @Injectable()
-export class TagsService {
+export class AutoTagsService {
 
   oneWordFreqMap: Map<string, number> = new Map();
   potentialTwoWordMap: Map<string, number> = new Map();
@@ -25,7 +25,7 @@ export class TagsService {
   cachedHub: string;
 
   constructor(
-    public tagsSaveService: TagsSaveService
+    public tagsSaveService: AutoTagsSaveService
   ) { }
 
   /**


### PR DESCRIPTION
First draft of tags:

Current tag color is not final - just picked one semi-randomly. Feel free to suggest a favorite color 😉 

In the _details_ view you can add tags and remove tags.
When closing the hub (or app) the tags should get saved and be restored when reopening the hub.

The app should be able to auto-complete the tag (just press the `tab` key) if the tag has been added before. You'll see the _typeahead_ appear as you type.

Hovering over the tag should show the `x` to remove the tag.

Currently clicking the tag does nothing.

There is also no way to see all the available tags yet.

@cal2195 - please merge the PR if you don't find bugs, unless you'd like me to change something.

Cheers 🎉 