### PR TITLE
Tag tray - first draft

### DIFF
--- a/src/app/components/common/settings-buttons.ts
+++ b/src/app/components/common/settings-buttons.ts
@@ -38,6 +38,7 @@ export const SettingsButtonsGroups: string[][] = [
   ],
   [
     'darkMode',
+    'showTagTray',
   ],
   [
     'showMoreInfo',
@@ -236,6 +237,13 @@ export let SettingsButtons: { [s: string]: SettingsButton } = {
     iconName: 'icon-darken',
     title: 'BUTTONS.darkModeHint',
     description: 'BUTTONS.darkModeDescription',
+  },
+  'showTagTray': {
+    hidden: false,
+    toggled: false,
+    iconName: 'icon-tag',
+    title: 'BUTTONS.tagTrayHint',
+    description: 'BUTTONS.tagTrayDescription',
   },
   'folderUnion': {
     hidden: true,

--- a/src/app/components/home/details/details.component.html
+++ b/src/app/components/home/details/details.component.html
@@ -53,6 +53,9 @@
       (tag)="addThisTag($event)"
     ></app-add-tag-component>
 
+    <!-- HACK for now -->
+    <br><br><br>
+
     <app-view-tags-component
       [tags]="tags"
       [allowRemoval]="true"

--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -888,6 +888,13 @@
 
 </div> <!-- end of window -->
 
+<div class="manual-tag-tray" *ngIf="settingsButtons['showTagTray'].toggled" @modalAnimation>
+  <span class="manual-tag-tray-label">
+    {{ 'TAGS.presentTags' | translate }}:
+  </span>
+  <app-view-tags-component [tags]="manualTagsService.tagsList"></app-view-tags-component>
+</div>
+
 <!-- IMPORT MODAL  -->
 
 <div

--- a/src/app/components/home/layout.scss
+++ b/src/app/components/home/layout.scss
@@ -210,3 +210,20 @@ $sidebar-width: 190px;
   z-index: 9999;
   cursor: pointer;
 }
+
+.manual-tag-tray {
+  background: $gray-10;
+  padding: 20px;
+  border-top: 1px solid $gray-50;
+  bottom: 0;
+  height: 100px;
+  left: 0;
+  position: fixed;
+  width: 100vw;
+}
+
+.manual-tag-tray-label {
+  display: block;
+  font-size: 12px;
+  margin-bottom: 10px;
+}

--- a/src/app/components/home/manual-tags/view-tags.component.html
+++ b/src/app/components/home/manual-tags/view-tags.component.html
@@ -1,21 +1,19 @@
-<div class="tagContainer">
-  <div
-    *ngFor="let tag of tags; index as i"
-    class="singleTag"
+<div
+  *ngFor="let tag of tags; index as i"
+  class="singleTag"
+>
+  <span *ngIf="allowRemoval" class="coverTheX">
+    &ensp;
+  </span>
+  <span
+    class="tag"
   >
-    <span class="coverTheX">
-      &ensp;
-    </span>
-    <span
-      class="tag"
-    >
-      {{ tag }}
-    </span>
-    <span
-      *ngIf="allowRemoval"
-      class="icon icon-close removeTag"
-      (click)="removeTag(tag)"
-    >
-    </span>
-  </div>
+    {{ tag }}
+  </span>
+  <span
+    *ngIf="allowRemoval"
+    class="icon icon-close removeTag"
+    (click)="removeTag(tag)"
+  >
+  </span>
 </div>

--- a/src/app/components/home/manual-tags/view-tags.component.scss
+++ b/src/app/components/home/manual-tags/view-tags.component.scss
@@ -1,9 +1,5 @@
 @import "../variables";
 
-.tagContainer {
-  margin-top: 50px;
-}
-
 .singleTag {
   display: inline-block;
   margin-right: 20px;

--- a/src/app/i18n/en.ts
+++ b/src/app/i18n/en.ts
@@ -83,6 +83,8 @@ export const English = {
     tagExclusionHint: 'Tag exclude filter',
     tagIntersectionDescription: 'Toggles the search for videos containing each of the search tags',
     tagIntersectionHint: 'Tag search',
+    tagTrayDescription: 'Show the tray with all the manual tags', // TRANSLATE
+    tagTrayHint: 'Show tag tray', // TRANSLATE
     tagUnionDescription: 'Toggles the search for videos containing any of the search tags',
     tagUnionHint: 'Tag union search',
     verifyThumbnailsDescription: 'Verify all files have thumbnails',
@@ -197,6 +199,7 @@ export const English = {
     alreadyExists: 'tag already exists',
     delete: 'delete',
     filterList: 'Filter list',
+    presentTags: 'Tags in this hub', // TRANSLATE
   },
   SHORTCUTS: {
     andPress: 'and press',


### PR DESCRIPTION
Currently: 
- new button next to the `dark mode`
- clicking it opens the tag tray (bottom)
- it lists current available tags
- 🎉 the list updates when you add new tags in the details view 🎉 

Later:
- will be able to show frequency of tags
- will be sortable (alphabetical or by frequency)
- clicking on a tag will add it to the _tag_ search