### PR TITLE
Input & pipe cleanup

### DIFF
--- a/main-support.ts
+++ b/main-support.ts
@@ -85,8 +85,10 @@ export function insertTemporaryFields(imagesArray: ImageElement[]): ImageElement
 
     // set resolution string & bucket
     const resolution: ResolutionMeta = labelVideo(element.width, element.height);
-    element.resolution = resolution.label;
+    element.durationDisplay = getDurationDisplay(element.duration);
+    element.fileSizeDisplay = getFileSizeDisplay(element.fileSize);
     element.resBucket = resolution.bucket;
+    element.resolution = resolution.label;
 
     // set index for default sorting
     element.index = counter;
@@ -94,6 +96,40 @@ export function insertTemporaryFields(imagesArray: ImageElement[]): ImageElement
   });
 
   return imagesArray;
+}
+
+/**
+ * Generate the file size formatted as XXXmb or X.Xgb
+ * @param fileSize
+ */
+function getFileSizeDisplay(sizeInBytes: number): string {
+  if (sizeInBytes) {
+    const rounded = Math.round(sizeInBytes / 1000000);
+    // tslint:disable-next-line:max-line-length
+    return (rounded > 999 ? Math.round(rounded / 100) / 10 + 'gb' : rounded + 'mb');
+  } else {
+    return '';
+  }
+}
+
+/**
+ * Generate duration formatted as X:XX:XX
+ * @param numOfSec
+ */
+function getDurationDisplay(numOfSec: number): string {
+
+  if (numOfSec === undefined || numOfSec === 0) {
+    return '';
+  } else {
+    const hh = (Math.floor(numOfSec / 3600)).toString();
+    const mm = (Math.floor(numOfSec / 60) % 60).toString();
+    const ss = (Math.floor(numOfSec) % 60).toString();
+
+    return (hh !== '0' ? hh + ':' : '')
+         + (mm.length !== 2 ? '0' + mm : mm)
+         + ':'
+         + (ss.length !== 2 ? '0' : '') + ss;
+  }
 }
 
 /**
@@ -135,6 +171,8 @@ export function writeVhaFileToDisk(finalObject: FinalObject, pathToTheFile: stri
  */
 function stripOutTemporaryFields(imagesArray: ImageElement[]): ImageElement[] {
   imagesArray.forEach((element) => {
+    delete(element.durationDisplay);
+    delete(element.fileSizeDisplay);
     delete(element.index);
     delete(element.resBucket);
     delete(element.resolution);
@@ -201,15 +239,17 @@ export function getVideoPathsAndNames(sourceFolderPath: string): ImageElement[] 
               finalArray[elementIndex] = {
                 cleanName: cleanUpFileName(file.name),
                 duration: 0,
+                durationDisplay: '',
                 fileName: file.name,
                 fileSize: 0,
+                fileSizeDisplay: '',
                 hash: '',
                 height: 0,
                 index: 0,
-                screens: 10, // hardcoded default
                 partialPath: partialPath,
                 resBucket: 0,
                 resolution: '',
+                screens: 10, // hardcoded default
                 stars: 0.5,
                 width: 0,
               };

--- a/src/app/components/common/final-object.interface.ts
+++ b/src/app/components/common/final-object.interface.ts
@@ -27,6 +27,8 @@ export interface ImageElement {
   // OPTIONAL
   tags?: string[];               // tags associated with this particular file
   // Stripped out and not saved in the VHA file
+  durationDisplay: string;       // displayed duration in X:XX:XX format
+  fileSizeDisplay: string;       // displayed as XXXmb or X.Xgb
   index: number;                 // for the `default` sort order
   resBucket: number;             // the resolution category the video falls into (for faster sorting)
   resolution: ResolutionString;  // e.g. `720`, `1080`, `SD`, `HD`

--- a/src/app/components/home/clip/clip.component.html
+++ b/src/app/components/home/clip/clip.component.html
@@ -12,7 +12,7 @@
   [ngStyle]="{ height: imgHeight + 'px' }"
 >
 
-  <span *ngIf="showMeta" class="time" @metaAppear>{{ video.duration | lengthPipe }}</span>
+  <span *ngIf="showMeta" class="time" @metaAppear>{{ video.durationDisplay }}</span>
   <span *ngIf="showMeta" class="rez" @metaAppear>{{ video.resolution }}</span>
 
   <video

--- a/src/app/components/home/clip/clip.component.html
+++ b/src/app/components/home/clip/clip.component.html
@@ -50,7 +50,7 @@
 >
   {{ video.cleanName }}
   <div class="fileSize" *ngIf="showMeta">
-    {{ showMeta ? ( video.fileSize | fileSizePipe ) : '' }}
+    {{ showMeta ? '(' + video.fileSizeDisplay + ')' : '' }}
   </div>
 </span>
 

--- a/src/app/components/home/clip/clip.component.html
+++ b/src/app/components/home/clip/clip.component.html
@@ -12,12 +12,12 @@
   [ngStyle]="{ height: imgHeight + 'px' }"
 >
 
-  <span *ngIf="showMeta" class="time" @metaAppear>{{ time | lengthPipe }}</span>
-  <span *ngIf="showMeta" class="rez" @metaAppear>{{ rez }}</span>
+  <span *ngIf="showMeta" class="time" @metaAppear>{{ video.duration | lengthPipe }}</span>
+  <span *ngIf="showMeta" class="rez" @metaAppear>{{ video.resolution }}</span>
 
   <video
     *ngIf="noError && !autoplay"
-    [src]="'file://' + folderPath + '/' + imgId"
+    [src]="'file://' + folderPath + '/' + pathToVideo"
     [poster]="sanitizer.bypassSecurityTrustUrl('file://' + folderPath + '/' + poster)"
     [ngStyle]="{ 'height': imgHeight + 'px' }"
     class="screencap"
@@ -28,7 +28,7 @@
 
   <video
     *ngIf="noError && autoplay"
-    [src]="'file://' + folderPath + '/' + imgId"
+    [src]="'file://' + folderPath + '/' + pathToVideo"
     [poster]="sanitizer.bypassSecurityTrustUrl('file://' + folderPath + '/' + poster)"
     [ngStyle]="{ 'height': imgHeight + 'px' }"
     class="screencap"
@@ -48,9 +48,9 @@
   class="title"
   @textAppear
 >
-  {{ title }}
+  {{ video.cleanName }}
   <div class="fileSize" *ngIf="showMeta">
-    {{ showMeta ? ( fileSize | fileSizePipe ) : '' }}
+    {{ showMeta ? ( video.fileSize | fileSizePipe ) : '' }}
   </div>
 </span>
 

--- a/src/app/components/home/clip/clip.component.ts
+++ b/src/app/components/home/clip/clip.component.ts
@@ -1,5 +1,8 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
+
+import { ImageElement } from '../../common/final-object.interface';
+
 import { galleryItemAppear, metaAppear, textAppear } from '../../common/animations';
 
 @Component({
@@ -12,26 +15,22 @@ import { galleryItemAppear, metaAppear, textAppear } from '../../common/animatio
 })
 export class ClipComponent implements OnInit {
 
+  @Input() video: ImageElement;
+
+  @Input() autoplay: boolean;
   @Input() darkMode: boolean;
   @Input() elHeight: number;
   @Input() elWidth: number;
-  @Input() fileSize: number;
   @Input() folderPath: string;
-  @Input() hoverScrub: boolean;
   @Input() hubName: string;
   @Input() imgHeight: number;
-  @Input() imgId: any;
-  @Input() poster: any;
   @Input() largerFont: boolean;
-  @Input() randomImage: boolean;
-  @Input() rez: string;
   @Input() showMeta: boolean;
-  @Input() time: string;
-  @Input() title: string;
-  @Input() autoplay: boolean;
 
   hover: boolean;
   noError = true;
+  poster: string;
+  pathToVideo: string = '';
 
   constructor(
     public sanitizer: DomSanitizer
@@ -39,13 +38,13 @@ export class ClipComponent implements OnInit {
 
   ngOnInit() {
     // this.imgId is `undefined` when no screenshot taken -- because of ffmpeg extraction error
-    if (this.imgId === undefined) {
+    if (this.video.hash === undefined) {
       this.noError = false;
     }
     // hack -- populate hardcoded values -- fix later
-    const fileHash = this.imgId;
+    const fileHash = this.video.hash;
 
-    this.imgId = 'vha-' + this.hubName + '/clips/' + fileHash + '.mp4';
+    this.pathToVideo = 'vha-' + this.hubName + '/clips/' + fileHash + '.mp4';
     this.poster = 'vha-' + this.hubName + '/thumbnails/' + fileHash + '.jpg';
   }
 }

--- a/src/app/components/home/details/details.component.html
+++ b/src/app/components/home/details/details.component.html
@@ -33,7 +33,7 @@
       {{ video.cleanName }}
     </span>
     <span class="fileSize">
-      {{ video.duration | lengthPipe }}
+      {{ video.durationDisplay }}
     </span>
     <span class="fileSize">
       {{ video.fileSizeDisplay }}

--- a/src/app/components/home/details/details.component.html
+++ b/src/app/components/home/details/details.component.html
@@ -36,7 +36,7 @@
       {{ video.duration | lengthPipe }}
     </span>
     <span class="fileSize">
-      {{ video.fileSize | fileSizePipe : true }}
+      {{ video.fileSizeDisplay }}
     </span>
     <span class="fileSize" *ngIf="video.width">
       {{ video.width }} x {{ video.height }}

--- a/src/app/components/home/file/file.component.html
+++ b/src/app/components/home/file/file.component.html
@@ -1,13 +1,12 @@
 <div
   class="element-container"
-  [ngStyle]="{ height: elHeight + 'px'}"
   @galleryItemAppear
 >
 
-  <div *ngIf="title === '***'; else fileNameBlock">
+  <div *ngIf="video.cleanName === '***'; else fileNameBlock">
     <span class="icon icon-folder-blank"></span>
     <span
-      [innerHtml]="folderPath | folderArrowsPipe : true"
+      [innerHtml]="video.partialPath | folderArrowsPipe : true"
       [ngStyle]="{ color: darkMode ? '#999999' : '#333333' }"
       class="folder"
     ></span>
@@ -21,7 +20,7 @@
       class="size"
       @metaAppear
     >
-      {{ rez }}
+      {{ video.resolution }}
     </div>
 
     <div
@@ -33,14 +32,14 @@
         }"
       [ngClass]="{ 'larger-font': largerFont }"
     >
-      {{ title }}
+      {{ video.cleanName }}
       <div
         *ngIf="showMeta"
         [ngStyle]="{ color: darkMode ? '#555555' : '#666666' }"
         class="fileSize"
         @metaAppear
       >
-        {{ fileSize | fileSizePipe }}
+        {{ video.fileSize | fileSizePipe }}
       </div>
     </div>
 
@@ -50,7 +49,7 @@
       class="length"
       @metaAppear
     >
-      {{ time | lengthPipe }}
+      {{ video.time | lengthPipe }}
     </div>
 
   </ng-template>

--- a/src/app/components/home/file/file.component.html
+++ b/src/app/components/home/file/file.component.html
@@ -17,7 +17,6 @@
       *ngIf="showMeta"
       [ngStyle]="{ color: darkMode ? '#555555' : '#BBBBBB' }"
       class="size"
-      @metaAppear
     >
       {{ video.resolution }}
     </div>
@@ -36,7 +35,6 @@
         *ngIf="showMeta"
         [ngStyle]="{ color: darkMode ? '#555555' : '#666666' }"
         class="fileSize"
-        @metaAppear
       >
         ({{ video.fileSizeDisplay }})
       </div>
@@ -48,7 +46,7 @@
       class="length"
       @metaAppear
     >
-      {{ video.duration | lengthPipe }}
+      {{ video.durationDisplay }}
     </div>
 
   </ng-template>

--- a/src/app/components/home/file/file.component.html
+++ b/src/app/components/home/file/file.component.html
@@ -1,6 +1,5 @@
 <div
   class="element-container"
-  @galleryItemAppear
 >
 
   <div *ngIf="video.cleanName === '***'; else fileNameBlock">
@@ -39,7 +38,7 @@
         class="fileSize"
         @metaAppear
       >
-        {{ video.fileSize | fileSizePipe }}
+        ({{ video.fileSizeDisplay }})
       </div>
     </div>
 
@@ -49,7 +48,7 @@
       class="length"
       @metaAppear
     >
-      {{ video.time | lengthPipe }}
+      {{ video.duration | lengthPipe }}
     </div>
 
   </ng-template>

--- a/src/app/components/home/file/file.component.scss
+++ b/src/app/components/home/file/file.component.scss
@@ -3,6 +3,7 @@
 .element-container {
   margin: 10px 20px;
   position: relative;
+  height: 20px;
 }
 
 .length,

--- a/src/app/components/home/file/file.component.ts
+++ b/src/app/components/home/file/file.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input } from '@angular/core';
 
 import { galleryItemAppear, metaAppear } from '../../common/animations';
+import { ImageElement } from '../../common/final-object.interface';
 
 @Component({
   selector: 'app-file-item',
@@ -12,16 +13,12 @@ import { galleryItemAppear, metaAppear } from '../../common/animations';
 })
 export class FileComponent {
 
-  @Input() elHeight: number;
-  @Input() fileSize: number;
-  @Input() folderPath: string;
+  @Input() video: ImageElement;
+
+  @Input() darkMode: boolean;
   @Input() imgId: any;
   @Input() largerFont: boolean;
-  @Input() rez: string;
   @Input() showMeta: boolean;
-  @Input() time: string;
-  @Input() title: string;
-  @Input() darkMode: boolean;
 
   constructor() { }
 

--- a/src/app/components/home/filmstrip/filmstrip.component.html
+++ b/src/app/components/home/filmstrip/filmstrip.component.html
@@ -26,7 +26,7 @@
   >
     {{ video.cleanName }}
     <div class="fileSize" *ngIf="showMeta">
-      {{ video.fileSize | fileSizePipe }}
+      ({{ video.fileSizeDisplay }})
     </div>
   </span>
 

--- a/src/app/components/home/filmstrip/filmstrip.component.html
+++ b/src/app/components/home/filmstrip/filmstrip.component.html
@@ -14,8 +14,8 @@
         'background-size': 'auto ' + imgHeight + 'px'
       }"
   >
-    <span *ngIf="showMeta" class="time" >{{ time | lengthPipe }}</span>
-    <span *ngIf="showMeta" class="rez" >{{ rez }}</span>
+    <span *ngIf="showMeta" class="time" >{{ video.duration | lengthPipe }}</span>
+    <span *ngIf="showMeta" class="rez" >{{ video.resolution }}</span>
   </div>
 
   <span
@@ -24,9 +24,9 @@
     [ngStyle]="{ color: darkMode ? '#BBBBBB' : '#000000' }"
     class="title"
   >
-    {{ title }}
+    {{ video.cleanName }}
     <div class="fileSize" *ngIf="showMeta">
-      {{ fileSize | fileSizePipe }}
+      {{ video.fileSize | fileSizePipe }}
     </div>
   </span>
 

--- a/src/app/components/home/filmstrip/filmstrip.component.html
+++ b/src/app/components/home/filmstrip/filmstrip.component.html
@@ -14,7 +14,7 @@
         'background-size': 'auto ' + imgHeight + 'px'
       }"
   >
-    <span *ngIf="showMeta" class="time" >{{ video.duration | lengthPipe }}</span>
+    <span *ngIf="showMeta" class="time" >{{ video.durationDisplay }}</span>
     <span *ngIf="showMeta" class="rez" >{{ video.resolution }}</span>
   </div>
 

--- a/src/app/components/home/filmstrip/filmstrip.component.ts
+++ b/src/app/components/home/filmstrip/filmstrip.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input, OnInit, ViewChild, ElementRef } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
 import { galleryItemAppear, metaAppear, textAppear } from '../../common/animations';
+import { ImageElement } from '../../common/final-object.interface';
 
 @Component({
   selector: 'app-filmstrip-item',
@@ -14,20 +15,16 @@ export class FilmstripComponent implements OnInit {
 
   @ViewChild('filmstripHolder') filmstripHolder: ElementRef;
 
+  @Input() video: ImageElement;
+
   @Input() darkMode: boolean;
   @Input() elHeight: number;
-  @Input() fileSize: number;
   @Input() folderPath: string;
   @Input() hoverScrub: boolean;
   @Input() hubName: string;
   @Input() imgHeight: number;
-  @Input() imgId: any;
   @Input() largerFont: boolean;
-  @Input() screens: number;
-  @Input() rez: string;
   @Input() showMeta: boolean;
-  @Input() time: string;
-  @Input() title: string;
 
   fullFilePath: string = '';
   filmXoffset: number = 0;
@@ -37,14 +34,14 @@ export class FilmstripComponent implements OnInit {
   ) { }
 
   ngOnInit() {
-    this.fullFilePath =  encodeURI('file://' + this.folderPath + '/' + 'vha-' + this.hubName + '/filmstrips/' + this.imgId + '.jpg');
+    this.fullFilePath =  'file://' + this.folderPath + '/' + 'vha-' + this.hubName + '/filmstrips/' + this.video.hash + '.jpg';
   }
 
   updateFilmXoffset($event) {
     if (this.hoverScrub) {
       const imgWidth = this.imgHeight * (16 / 9); // hardcoded aspect ratio
       const containerWidth = this.filmstripHolder.nativeElement.getBoundingClientRect().width;
-      const howManyScreensOutsideCutoff = (this.screens + 1) - Math.floor(containerWidth / imgWidth);
+      const howManyScreensOutsideCutoff = (this.video.screens + 1) - Math.floor(containerWidth / imgWidth);
 
       const cursorX = $event.layerX; // cursor's X position inside the filmstrip element
       this.filmXoffset = imgWidth * Math.floor(cursorX / (containerWidth / howManyScreensOutsideCutoff));

--- a/src/app/components/home/full/full.component.html
+++ b/src/app/components/home/full/full.component.html
@@ -27,7 +27,7 @@
   >
     {{ video.cleanName }}
     <div class="fileSize" *ngIf="showMeta">
-      {{ video.fileSize | fileSizePipe }}
+      ({{ video.fileSizeDisplay }})
     </div>
   </span>
 

--- a/src/app/components/home/full/full.component.html
+++ b/src/app/components/home/full/full.component.html
@@ -25,9 +25,9 @@
     [ngStyle]="{ color: darkMode ? '#BBBBBB' : '#000000' }"
     class="title"
   >
-    {{ title }}
+    {{ video.cleanName }}
     <div class="fileSize" *ngIf="showMeta">
-      {{ fileSize | fileSizePipe }}
+      {{ video.fileSize | fileSizePipe }}
     </div>
   </span>
 

--- a/src/app/components/home/full/full.component.ts
+++ b/src/app/components/home/full/full.component.ts
@@ -1,5 +1,8 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
+
+import { ImageElement } from '../../common/final-object.interface';
+
 import { galleryItemAppear, metaAppear, textAppear } from '../../common/animations';
 
 @Component({
@@ -25,18 +28,14 @@ export class FullViewComponent implements OnInit {
     this.render();
   }
 
+  @Input() video: ImageElement;
+
   @Input() darkMode: boolean;
   @Input() elHeight: number;
-  @Input() fileSize: number;
   @Input() folderPath: string;
   @Input() hubName: string;
-  @Input() imgId: any;
   @Input() largerFont: boolean;
-  @Input() screens: number;
-  @Input() rez: string;
   @Input() showMeta: boolean;
-  @Input() time: string;
-  @Input() title: string;
 
   _imgHeight: number;
   _metaWidth: number;
@@ -49,7 +48,7 @@ export class FullViewComponent implements OnInit {
   ) { }
 
   ngOnInit() {
-    this.fullFilePath = encodeURI('file://' + this.folderPath + '/' + 'vha-' + this.hubName + '/filmstrips/' + this.imgId + '.jpg');
+    this.fullFilePath = 'file://' + this.folderPath + '/' + 'vha-' + this.hubName + '/filmstrips/' + this.video.hash + '.jpg';
     this.render();
   }
 
@@ -57,7 +56,10 @@ export class FullViewComponent implements OnInit {
     const imgWidth = this._imgHeight * 16 / 9;
     const imagesPerRow = Math.floor(this._metaWidth / imgWidth) || 1; // never let this be zero
     this.computedWidth = imgWidth * imagesPerRow;
-    const numOfRows = Math.ceil(this.screens / imagesPerRow);
+    console.log(this.video);
+    // !!! WARNING !!! ### !!! ??? WHY IS `video` undefined sometimes in this view?
+    // TODO -- investigate why `video` is sometimes undefined!
+    const numOfRows = Math.ceil((<any>(this.video || {screens: 0}).screens) / imagesPerRow);
     this.rowOffsets = [];
     for (let i = 0; i < numOfRows; i++) {
       this.rowOffsets.push(i * Math.floor(this._metaWidth / imgWidth));

--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -167,18 +167,13 @@
     <app-filmstrip-item
       [darkMode]="settingsButtons['darkMode'].toggled"
       [elHeight]="150"
-      [fileSize]="itemToRename.fileSize"
       [folderPath]="appState.selectedOutputFolder"
       [hoverScrub]="true"
       [hubName]="appState.hubName"
       [imgHeight]="100"
-      [imgId]="itemToRename.hash"
       [largerFont]="true"
-      [screens]="itemToRename.screens"
-      [rez]="itemToRename.resolution"
       [showMeta]="true"
-      [time]="itemToRename.duration"
-      [title]="itemToRename.fileName"
+      [video]="itemToRename"
     ></app-filmstrip-item>
 
     <span class="renameFrom">{{ 'RIGHTCLICK.renameFrom' | translate }}</span>
@@ -762,17 +757,15 @@
           *ngFor="let item of scroll.viewPortItems"
           (click)="handleClick($event, item)"
           (contextmenu)="rightMouseClicked($event, item)"
+
           [elHeight]="imgHeight + textPaddingHeight"
           [elWidth]="previewWidth"
-          [fileSize]="item.fileSize"
           [folderPath]="appState.selectedOutputFolder"
           [hubName]="appState.hubName"
           [imgHeight]="imgHeight"
-          [imgId]="item.hash"
-          [screens]="item.screens"
-          [rez]="item.resolution"
-          [time]="item.duration"
-          [title]="item.cleanName"
+
+          [video]="item"
+
           [darkMode]="settingsButtons['darkMode'].toggled"
           [hoverScrub]="settingsButtons['hoverScrub'].toggled"
           [largerFont]="settingsButtons['fontSizeLarger'].toggled"
@@ -787,16 +780,14 @@
           *ngFor="let item of scroll.viewPortItems"
           (click)="handleClick($event, item)"
           (contextmenu)="rightMouseClicked($event, item)"
+
+          [video]="item"
+
           [elHeight]="imgHeight + textPaddingHeight"
-          [fileSize]="item.fileSize"
           [folderPath]="appState.selectedOutputFolder"
           [hubName]="appState.hubName"
           [imgHeight]="imgHeight"
-          [imgId]="item.hash"
-          [screens]="item.screens"
-          [rez]="item.resolution"
-          [time]="item.duration"
-          [title]="item.cleanName"
+
           [darkMode]="settingsButtons['darkMode'].toggled"
           [hoverScrub]="settingsButtons['hoverScrub'].toggled"
           [largerFont]="settingsButtons['fontSizeLarger'].toggled"
@@ -809,17 +800,15 @@
           *ngFor="let item of scroll.viewPortItems"
           (click)="handleClick($event, item)"
           (contextmenu)="rightMouseClicked($event, item)"
+
+          [video]="item"
+
           [elHeight]="imgHeight + textPaddingHeight"
-          [fileSize]="item.fileSize"
           [folderPath]="appState.selectedOutputFolder"
+          [galleryWidth]="galleryWidth"
           [hubName]="appState.hubName"
           [imgHeight]="imgHeight"
-          [galleryWidth]="galleryWidth"
-          [imgId]="item.hash"
-          [screens]="item.screens"
-          [rez]="item.resolution"
-          [time]="item.duration"
-          [title]="item.cleanName"
+
           [darkMode]="settingsButtons['darkMode'].toggled"
           [largerFont]="settingsButtons['fontSizeLarger'].toggled"
           [showMeta]="settingsButtons['showMoreInfo'].toggled"
@@ -829,14 +818,11 @@
       <ng-container *ngIf="appState.currentView === 'files'">
         <app-file-item
           *ngFor="let item of scroll.viewPortItems"
-          [folderPath]="item.partialPath"
-          [title]="item.cleanName"
-          (click)="(item.cleanName === '***') ? handleFolderWordClicked(item.partialPath) : openVideo(item.hash)"
           (contextmenu)="(item.cleanName === '***') ? doNothing() : rightMouseClicked($event, item)"
-          [time]="item.duration"
-          [rez]="item.resolution"
-          [fileSize]="item.fileSize"
-          [elHeight]="20"
+          (click)="(item.cleanName === '***') ? handleFolderWordClicked(item.partialPath) : openVideo(item.hash)"
+
+          [video]="item"
+
           [largerFont]="settingsButtons['fontSizeLarger'].toggled"
           [showMeta]="settingsButtons['showMoreInfo'].toggled"
           [darkMode]="settingsButtons['darkMode'].toggled"
@@ -846,24 +832,22 @@
       <ng-container *ngIf="appState.currentView === 'clips'">
         <app-clip-item
           *ngFor="let item of scroll.viewPortItems"
+
           (click)="handleClick($event, item)"
           (contextmenu)="rightMouseClicked($event, item)"
-          [title]="item.cleanName"
-          [imgId]="item.hash"
-          [time]="item.duration"
-          [rez]="item.resolution"
-          [fileSize]="item.fileSize"
-          [imgHeight]="imgHeight"
+
+          [video]="item"
+
           [elHeight]="imgHeight + textPaddingHeight"
           [elWidth]="previewWidth"
-          [hubName]="appState.hubName"
           [folderPath]="appState.selectedOutputFolder"
+          [hubName]="appState.hubName"
+          [imgHeight]="imgHeight"
+
+          [autoplay]="settingsButtons['autoplayClips'].toggled"
+          [darkMode]="settingsButtons['darkMode'].toggled"
           [largerFont]="settingsButtons['fontSizeLarger'].toggled"
           [showMeta]="settingsButtons['showMoreInfo'].toggled"
-          [hoverScrub]="settingsButtons['hoverScrub'].toggled"
-          [randomImage]="settingsButtons['randomImage'].toggled"
-          [darkMode]="settingsButtons['darkMode'].toggled"
-          [autoplay]="settingsButtons['autoplayClips'].toggled"
         ></app-clip-item>
       </ng-container>
 
@@ -874,15 +858,19 @@
           (openFileRequest)="openVideo($event)"
           (editFinalArrayTag)="editFinalArrayTag($event)"
           (editFinalArrayStars)="editFinalArrayStars($event)"
+
           [video]="item"
+
           [elHeight]="imgHeight + textPaddingHeight"
           [elWidth]="previewWidth"
-          [tags]="item.tags"
           [folderPath]="appState.selectedOutputFolder"
           [hubName]="appState.hubName"
           [imgHeight]="imgHeight"
+
+          [tags]="item.tags"
           [imgId]="item.hash"
           [star]="item.stars"
+
           [darkMode]="settingsButtons['darkMode'].toggled"
           [hoverScrub]="settingsButtons['hoverScrub'].toggled"
           [largerFont]="settingsButtons['fontSizeLarger'].toggled"

--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -125,17 +125,15 @@
   <!-- Thumbnail Sheet Display -->
   <app-thumbnail-sheet
     *ngIf="sheetDisplay"
+
     [elHeight]="imgHeight"
     [elWidth]="previewWidth"
-    [fileSize]="itemToDisplay.fileSize"
     [folderPath]="appState.selectedOutputFolder"
     [hubName]="appState.hubName"
     [imgHeight]="imgHeight"
-    [imgId]="itemToDisplay.hash"
-    [screens]="itemToDisplay.screens"
-    [rez]="itemToDisplay.resolution"
-    [time]="itemToDisplay.duration"
-    [title]="itemToDisplay.cleanName"
+
+    [video]="itemToDisplay"
+
     [darkMode]="settingsButtons['darkMode'].toggled"
     [hoverScrub]="settingsButtons['hoverScrub'].toggled"
     [largerFont]="settingsButtons['fontSizeLarger'].toggled"

--- a/src/app/components/home/sheet/sheet.component.html
+++ b/src/app/components/home/sheet/sheet.component.html
@@ -4,10 +4,11 @@
   <div
     class="sheet-info"
   >
-    <div class="meta-info" >Title: {{ title }}</div>
-    <div class="meta-info" >Duration: {{ time | lengthPipe }}</div>
-    <div class="meta-info" >Size: {{ fileSize | fileSizePipe : true }}</div>
-    <div class="meta-info" >Resolution: {{ rez }}</div>
+    <!-- TODO - TRANSLATE & UPDATE CSS -->
+    <div class="meta-info"><small>Title:</small> {{ video.cleanName }}</div>
+    <div class="meta-info"><small>Duration:</small> {{ video.durationDisplay }}</div>
+    <div class="meta-info"><small>Size:</small> {{ video.fileSizeDisplay }}</div>
+    <div class="meta-info"><small>Resolution:</small> {{ video.width }} x {{ video.height }}</div>
   </div>
 
   <div style="margin: 20px">
@@ -30,7 +31,7 @@
   </div>
 
   <ng-container
-  *ngFor="let dummy of ' '.repeat(screens).split(''); index as i"
+  *ngFor="let dummy of ' '.repeat(video.screens).split(''); index as i"
   >
     <div
       [ngStyle]="{
@@ -50,7 +51,7 @@
             'background-position-x': (percentOffset * i) + '%'
           }"
       >
-      <span *ngIf="showMeta" class="time" @metaAppear>{{ (time / screens) * (i+1) | lengthPipe }}</span>
+      <span *ngIf="showMeta" class="time" @metaAppear>{{ (video.duration / video.screens) * (i+1) | lengthPipe }}</span>
       </div>
     </div>
   </ng-container>

--- a/src/app/components/home/sheet/sheet.component.scss
+++ b/src/app/components/home/sheet/sheet.component.scss
@@ -12,8 +12,10 @@
   overflow-y: scroll;
   top: 10%;
   height: 80vh;
-  width: 80vw;
+  width: calc(80vw + 10px);
   z-index: 30;
+
+  @include scrollBar;
 }
 
 .filmstrip-container {

--- a/src/app/components/home/sheet/sheet.component.ts
+++ b/src/app/components/home/sheet/sheet.component.ts
@@ -1,5 +1,8 @@
-import { Component, HostListener, Input, OnInit, ElementRef, ViewChild } from '@angular/core';
+import { Component, Input, OnInit, ElementRef, ViewChild } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
+
+import { ImageElement } from '../../common/final-object.interface';
+
 import { galleryItemAppear, metaAppear, textAppear } from '../../common/animations';
 
 @Component({
@@ -15,24 +18,19 @@ export class SheetComponent implements OnInit {
   @ViewChild('filmstripHolder') filmstripHolder: ElementRef;
   @ViewChild('thumbHolder') thumbHolder: ElementRef;
 
+  @Input() video: ImageElement;
 
   @Input() darkMode: boolean;
   @Input() elHeight: number;
   @Input() elWidth: number;
-  @Input() fileSize: number;
   @Input() folderPath: string;
   @Input() hoverScrub: boolean;
   @Input() hubName: string;
   @Input() imgHeight: number;
-  @Input() imgId: any; // the filename of screenshot strip without `.jpg`
   @Input() largerFont: boolean;
-  @Input() screens: number;
   @Input() randomImage: boolean; // all code related to this currently removed
   @Input() returnToFirstScreenshot: boolean;
-  @Input() rez: string;
   @Input() showMeta: boolean;
-  @Input() time: number;
-  @Input() title: string;
 
   percentOffset: number = 0;
   fullFilePath = '';
@@ -43,8 +41,8 @@ export class SheetComponent implements OnInit {
   ) { }
 
   ngOnInit() {
-    this.fullFilePath =  'file://' + this.folderPath + '/' + 'vha-' + this.hubName + '/filmstrips/' + this.imgId + '.jpg';
-    this.percentOffset = (100 / (this.screens - 1));
+    this.fullFilePath =  'file://' + this.folderPath + '/' + 'vha-' + this.hubName + '/filmstrips/' + this.video.hash + '.jpg';
+    this.percentOffset = (100 / (this.video.screens - 1));
   }
 
   decreaseZoomLevel() {

--- a/src/app/components/home/thumbnail/preview.component.html
+++ b/src/app/components/home/thumbnail/preview.component.html
@@ -17,8 +17,8 @@
         'background-position-x': percentOffset + '%'
       }"
   >
-    <span *ngIf="showMeta" class="time" @metaAppear>{{ time | lengthPipe }}</span>
-    <span *ngIf="showMeta" class="rez" @metaAppear>{{ rez }}</span>
+    <span *ngIf="showMeta" class="time" @metaAppear>{{ video.duration | lengthPipe }}</span>
+    <span *ngIf="showMeta" class="rez" @metaAppear>{{ video.resolution }}</span>
   </div>
 
   <span
@@ -28,9 +28,9 @@
     class="title"
     @textAppear
   >
-    {{ title }}
+    {{ video.cleanName }}
     <div class="fileSize" *ngIf="showMeta">
-      {{ showMeta ? ( fileSize | fileSizePipe ) : '' }}
+      {{ showMeta ? ( video.fileSize | fileSizePipe ) : '' }}
     </div>
   </span>
 

--- a/src/app/components/home/thumbnail/preview.component.html
+++ b/src/app/components/home/thumbnail/preview.component.html
@@ -30,7 +30,7 @@
   >
     {{ video.cleanName }}
     <div class="fileSize" *ngIf="showMeta">
-      {{ showMeta ? ( video.fileSize | fileSizePipe ) : '' }}
+      {{ showMeta ? '(' + video.fileSizeDisplay + ')' : '' }}
     </div>
   </span>
 

--- a/src/app/components/home/thumbnail/preview.component.html
+++ b/src/app/components/home/thumbnail/preview.component.html
@@ -17,7 +17,7 @@
         'background-position-x': percentOffset + '%'
       }"
   >
-    <span *ngIf="showMeta" class="time" @metaAppear>{{ video.duration | lengthPipe }}</span>
+    <span *ngIf="showMeta" class="time" @metaAppear>{{ video.durationDisplay }}</span>
     <span *ngIf="showMeta" class="rez" @metaAppear>{{ video.resolution }}</span>
   </div>
 

--- a/src/app/components/home/thumbnail/preview.component.ts
+++ b/src/app/components/home/thumbnail/preview.component.ts
@@ -1,6 +1,7 @@
 import { Component, HostListener, Input, OnInit, ElementRef, ViewChild } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
 import { galleryItemAppear, metaAppear, textAppear } from '../../common/animations';
+import { ImageElement } from '../../common/final-object.interface';
 
 @Component({
   selector: 'app-gallery-item',
@@ -14,23 +15,19 @@ export class PreviewComponent implements OnInit {
 
   @ViewChild('filmstripHolder') filmstripHolder: ElementRef;
 
+  @Input() video: ImageElement;
+
   @Input() darkMode: boolean;
   @Input() elHeight: number;
   @Input() elWidth: number;
-  @Input() fileSize: number;
   @Input() folderPath: string;
   @Input() hoverScrub: boolean;
   @Input() hubName: string;
   @Input() imgHeight: number;
-  @Input() imgId: any; // the filename of screenshot strip without `.jpg`
   @Input() largerFont: boolean;
-  @Input() screens: number;
   @Input() randomImage: boolean; // all code related to this currently removed
   @Input() returnToFirstScreenshot: boolean;
-  @Input() rez: string;
   @Input() showMeta: boolean;
-  @Input() time: string;
-  @Input() title: string;
 
   percentOffset: number = 0;
   firstFilePath = '';
@@ -54,8 +51,8 @@ export class PreviewComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.firstFilePath = encodeURI('file://' + this.folderPath + '/' + 'vha-' + this.hubName + '/thumbnails/' + this.imgId + '.jpg');
-    this.fullFilePath =  encodeURI('file://' + this.folderPath + '/' + 'vha-' + this.hubName + '/filmstrips/' + this.imgId + '.jpg');
+    this.firstFilePath = 'file://' + this.folderPath + '/' + 'vha-' + this.hubName + '/thumbnails/' + this.video.hash + '.jpg';
+    this.fullFilePath =  'file://' + this.folderPath + '/' + 'vha-' + this.hubName + '/filmstrips/' + this.video.hash + '.jpg';
   }
 
   mouseIsMoving($event) {
@@ -63,7 +60,7 @@ export class PreviewComponent implements OnInit {
       const cursorX = $event.layerX;
       const containerWidth = this.filmstripHolder.nativeElement.getBoundingClientRect().width;
 
-      this.percentOffset = (100 / (this.screens - 1)) * Math.floor(cursorX / (containerWidth / this.screens));
+      this.percentOffset = (100 / (this.video.screens - 1)) * Math.floor(cursorX / (containerWidth / this.video.screens));
     }
   }
 

--- a/src/app/components/pipes/folder-view.pipe.ts
+++ b/src/app/components/pipes/folder-view.pipe.ts
@@ -26,15 +26,17 @@ export class FolderViewPipe implements PipeTransform {
           const tempClone: ImageElement = {
             cleanName: '***',
             duration: 0,
+            durationDisplay: '',
             fileName: element.fileName,
             fileSize: 0,
+            fileSizeDisplay: '',
             hash: '',
             height: 0,
             index: 0,
-            screens: 10, // temp hardcoded
             partialPath: element.partialPath,
             resBucket: 0,
             resolution: '',
+            screens: 10, // temp hardcoded
             stars: 0.5,
             width: 0,
           };


### PR DESCRIPTION
As more properties began to be added to the gallery elements, the _Inputs()_ list grew enormously.

This PR simplifies this by passing in the `video` (_ImageElement_) into each gallery display item, which in turns retrieves whichever property it wants (_resolution_, _duration_, etc).

Additionally, this PR removes the vast majority of the _timePipe_ and _fileSizePipe_ - to speed up the display when scrolling. The two display properties are now pre-computed every time a _vha_ file is opened (and removed whenever the _vha_ file is saved).