### PR TITLE
Implement regenerating library metadata!

### DIFF
--- a/main-support.ts
+++ b/main-support.ts
@@ -149,6 +149,8 @@ export function countFoldersInFinalArray(imagesArray: ImageElement[]): number {
  * @param done          -- function to execute when done writing the file
  */
 export function writeVhaFileToDisk(finalObject: FinalObject, pathToTheFile: string, done): void {
+  const inputDir = finalObject.inputDir;
+
   // check for relative paths
   if (finalObject.inputDir === path.parse(pathToTheFile).dir) {
     finalObject.inputDir = '';
@@ -160,6 +162,9 @@ export function writeVhaFileToDisk(finalObject: FinalObject, pathToTheFile: stri
   // write the file
   fs.writeFile(pathToTheFile, json, 'utf8', done);
   // CATCH ERRORS !?!!?!!
+
+  // Restore the inputDir incase we removed it
+  finalObject.inputDir = inputDir;
 }
 
 /**

--- a/main-support.ts
+++ b/main-support.ts
@@ -645,6 +645,40 @@ export function finalArrayWithoutDeleted(
   return cleanedArray;
 }
 
+/**
+ * Copy all user metadata from oldElement to newElement
+ * @param oldElement
+ * @param newElement
+ */
+export function copyUserMetadataForFile(
+  oldElement: ImageElement,
+  newElement: ImageElement
+) {
+  // TODO update this as needed
+  newElement.stars = oldElement.stars;
+  newElement.tags = oldElement.tags;
+  newElement.timesPlayed = oldElement.timesPlayed;
+  newElement.year = oldElement.year;
+}
+
+/**
+ * Copy any user entered metadata from oldArray to newArray by hash key
+ * @param oldArray to copy from
+ * @param newArray to copy to
+ */
+export function copyUserMetadata(
+  oldArray: ImageElement[],
+  newArray: ImageElement[]
+) {
+  oldArray.forEach((oldElement) => {
+    newArray.forEach((newElement) => {
+      if (oldElement.hash === newElement.hash) {
+        copyUserMetadataForFile(oldElement, newElement);
+      }
+    });
+  });
+}
+
 // --------------------------------------------------------------------------------------------
 // -- EXTRACT METADATA --
 // --------------------------------------------------------------------------------------------
@@ -815,6 +849,9 @@ export function findAndImportNewFiles(
   const onlyNewElements: ImageElement[] =
     findAllNewFiles(angularFinalArray, hdFinalArray, inputFolder);
 
+  // Copy any metadata incase files were moved
+  copyUserMetadata(angularFinalArray, onlyNewElements);
+
   // If there are new files
   if (onlyNewElements.length > 0) {
 
@@ -862,6 +899,9 @@ export function updateFinalArrayWithHD(
   // Generate ImageElement[] of all the new elements to be added
   const onlyNewElements: ImageElement[] =
     findAllNewFiles(angularFinalArray, hdFinalArray, inputFolder);
+
+  // Copy any metadata incase files were moved
+  copyUserMetadata(angularFinalArray, onlyNewElements);
 
   // remove from FinalArray all files that are no longer in the video folder
   const allDeletedRemoved: ImageElement[] =

--- a/src/app/components/common/final-object.interface.ts
+++ b/src/app/components/common/final-object.interface.ts
@@ -1,7 +1,7 @@
 import { ResolutionString } from '../pipes/resolution-filter.service';
 import { ScreenshotSettings } from '../../../../main-globals';
 
-export type StarRating = 0.5 | 1.5 | 2.5 | 3.5;
+export type StarRating = 0.5 | 1.5 | 2.5 | 3.5 | 4.5 | 5.5;
 
 export interface FinalObject {
   addTags?: string[];           // tags to add

--- a/src/app/components/common/settings-buttons.ts
+++ b/src/app/components/common/settings-buttons.ts
@@ -80,6 +80,7 @@ export const SettingsButtonsGroups: string[][] = [
     'rescanDirectory',
     'importNewFiles',
     'verifyThumbnails',
+    'regenerateLibrary',
     'resetSettings',
     'clearHistory'
   ]
@@ -531,5 +532,12 @@ export let SettingsButtons: { [s: string]: SettingsButton } = {
     title: 'BUTTONS.rescanDirectoryHint',
     description: 'BUTTONS.rescanDirectoryDescription',
     settingsHeading: 'SETTINGS.currentHub'
+  },
+  'regenerateLibrary': {
+    hidden: false,
+    toggled: false,
+    iconName: 'icon-checkmark', // this specific icon makes the setting only appear in All Settings (behind gear button)
+    title: 'BUTTONS.regenerateLibraryHint',
+    description: 'BUTTONS.regenerateLibraryDescription',
   }
 };

--- a/src/app/components/home/home.component.ts
+++ b/src/app/components/home/home.component.ts
@@ -948,6 +948,8 @@ export class HomeComponent implements OnInit, AfterViewInit {
       this.verifyThumbnails();
     } else if (uniqueKey === 'rescanDirectory') {
       this.rescanDirectory();
+    } else if (uniqueKey === 'regenerateLibrary') {
+      this.regenerateLibrary();
     } else if (uniqueKey === 'sortOrder') {
       this.sortType = 'default';
       this.toggleButtonOpposite(uniqueKey);
@@ -1046,6 +1048,17 @@ export class HomeComponent implements OnInit, AfterViewInit {
     this.toggleSettings();
     console.log('rescanning');
     this.electronService.ipcRenderer.send('rescan-current-directory', this.finalArray);
+  }
+
+  /**
+   * Regenerate the library
+   */
+  public regenerateLibrary(): void {
+    this.progressNum1 = 0;
+    this.importStage = 1;
+    this.toggleSettings();
+    console.log('regenerating library');
+    this.electronService.ipcRenderer.send('regenerate-library', this.finalArray);
   }
 
   /**

--- a/src/app/i18n/en.ts
+++ b/src/app/i18n/en.ts
@@ -49,6 +49,8 @@ export const English = {
     randomImageHint: 'Show random screenshot',
     randomizeGalleryDescription: 'Randomizes the order of video files after every search',
     randomizeGalleryHint: 'Randomize gallery order',
+    regenerateLibraryDescription: 'Regenerate all library metadata, except thumbnails and user entered metadata',
+    regenerateLibraryHint: 'Regenerate library',
     rescanDirectoryDescription: 'Rescan the video folder for any file changes (addition, renaming, deletion of videos) and update the current hub',
     rescanDirectoryHint: 'Rescan directory',
     resetSettingsDescription: 'Reset settings and buttons to their default values',


### PR DESCRIPTION
This PR implements #117, as well as a sprinkling of bug fixes! 🐛 🐞 

Firstly, it implements copying user generated metadata, such as star rating, tags, and play times to when files are moved and renamed using the rescan function previously added - previously, renaming a file would result in the tags being lost. 👎 

Secondly, it implements a full library regeneration of all metadata, keeping thumbnails and user metadata! 🎉  This will be very helpful for when new features are added, but your library hasn't scanned for the required metadata - you can just rescan the metadata, but keep all your tags and thumbnails! 👍 

PS: This does have a *slight* side effect that using this function will apply the user metadata to all duplicate files as well (by hash), but since it doesn't make much sense having duplicates that don't share the same metadata anyway, I'm not too worried. It might be a better idea to apply the tags, stars etc. hash-wide so all duplicates always have the same tags, but it's currently more effort then reward!