### PR TITLE
Auto child sizes

### DIFF
--- a/src/app/components/home/file/file.component.scss
+++ b/src/app/components/home/file/file.component.scss
@@ -1,7 +1,7 @@
 @import "../variables";
 
 .element-container {
-  margin: 10px 20px;
+  margin: 10px 20px 0px 20px;
   position: relative;
   height: 20px;
 }

--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -816,9 +816,6 @@
           'gallery-dark-scroll': settingsButtons['darkMode'].toggled
         }"
       [bufferAmount]="0"
-      [childHeight]="currentViewImgHeight + textPaddingHeight + 20
-                      + ( appState.currentView === 'showThumbnails' ? 4 : 0)
-                      - ( appState.currentView === 'showFiles' ? ( currentViewImgHeight + 10 ) : 0)"
       [items]="finalArray
                 | magicSearchPipe: magicSearchString
 


### PR DESCRIPTION
This PR removes the fixed child size calculation, and uses auto child sizing instead, based on the first element of each virtual-scroller!

This also fixes the file element margins, so that their sizes are correctly calculated (a recent bug that had snuck in)! 👍 