### PR TITLE
Zoom by number of images per row

### DIFF
--- a/src/app/components/common/app-state.ts
+++ b/src/app/components/common/app-state.ts
@@ -21,7 +21,7 @@ export const allSupportedViews: SupportedView[] = [
   'showClips',
 ];
 
-export interface ImageHeights {
+export interface RowNumbers {
   thumbnailSheet: number;
   showThumbnails: number;
   showFilmstrip: number;
@@ -30,13 +30,13 @@ export interface ImageHeights {
   showClips: number;
 }
 
-export const defaultHeights: ImageHeights = {
-  thumbnailSheet: 144,
-  showThumbnails: 144,
-  showFilmstrip: 144,
-  showFullView: 144,
-  showDetails: 144,
-  showClips: 144,
+export const defaultImgsPerRow: RowNumbers = {
+  thumbnailSheet: 5,
+  showThumbnails: 5,
+  showFilmstrip: 5,
+  showFullView: 5,
+  showDetails: 4,
+  showClips: 4,
 };
 
 export let AppState: AppStateInterface = {
@@ -44,7 +44,7 @@ export let AppState: AppStateInterface = {
   currentView: 'showThumbnails',
   currentZoomLevel: 1,
   hubName: '',
-  imgHeight: defaultHeights,         // gallery/filmstrip height
+  imgsPerRow: defaultImgsPerRow,         // gallery/filmstrip height
   language: 'en',
   menuHidden: false,
   numOfFolders: 0,
@@ -57,7 +57,7 @@ export interface AppStateInterface {
   currentView: SupportedView;
   currentZoomLevel: number;
   hubName: string;
-  imgHeight: ImageHeights;
+  imgsPerRow: RowNumbers;
   language: SupportedLanguage;
   menuHidden: boolean;
   numOfFolders: number;

--- a/src/app/components/home/file/file.component.scss
+++ b/src/app/components/home/file/file.component.scss
@@ -1,7 +1,7 @@
 @import "../variables";
 
 .element-container {
-  margin: 10px 20px;
+  margin: 10px 20px 0px 20px;
   position: relative;
   height: 20px;
 }

--- a/src/app/components/home/full/full.component.ts
+++ b/src/app/components/home/full/full.component.ts
@@ -17,8 +17,7 @@ export class FullViewComponent implements OnInit {
 
   @Input()
   set galleryWidth(galleryWidth: number) {
-    this._metaWidth = galleryWidth - 40;
-    // 40px is removed as required padding inside the gallery
+    this._metaWidth = galleryWidth;
     this.render();
   }
 

--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -816,9 +816,6 @@
           'gallery-dark-scroll': settingsButtons['darkMode'].toggled
         }"
       [bufferAmount]="0"
-      [childHeight]="currentViewImgHeight + textPaddingHeight + 20
-                      + ( appState.currentView === 'showThumbnails' ? 4 : 0)
-                      - ( appState.currentView === 'showFiles' ? ( currentViewImgHeight + 10 ) : 0)"
       [items]="finalArray
                 | magicSearchPipe: magicSearchString
 

--- a/src/app/components/home/home.component.ts
+++ b/src/app/components/home/home.component.ts
@@ -127,6 +127,7 @@ export class HomeComponent implements OnInit, AfterViewInit {
   imgHeight: ImageHeights = defaultHeights;
 
   currentViewImgHeight: number = 144;
+  currentViewPerRow: number = 4;
 
   progressNum1 = 0;
   progressNum2 = 100;
@@ -535,7 +536,7 @@ export class HomeComponent implements OnInit, AfterViewInit {
   }
 
   ngAfterViewInit() {
-    this.updateGalleryWidthMeasurement(); // so that fullView knows its size
+    this.computePreviewWidth(); // so that fullView knows its size
     // this is required, otherwise when user drops the file, it opens as plaintext
     document.ondragover = document.ondrop = (ev) => {
       ev.preventDefault();
@@ -564,9 +565,7 @@ export class HomeComponent implements OnInit, AfterViewInit {
     this.myTimeout = setTimeout(() => {
       // console.log('Virtual scroll refreshed');
       this.virtualScroller.refresh();
-      if (this.appState.currentView === 'showFullView') {
-        this.updateGalleryWidthMeasurement();
-      }
+      this.computePreviewWidth();
     }, delay);
   }
 
@@ -770,7 +769,7 @@ export class HomeComponent implements OnInit, AfterViewInit {
   showSidebar(): void {
     if (this.settingsButtons['hideSidebar'].toggled) {
       this.toggleButton('hideSidebar');
-      this.updateGalleryWidthMeasurement();
+      this.computePreviewWidth();
     }
   }
 
@@ -932,10 +931,8 @@ export class HomeComponent implements OnInit, AfterViewInit {
     // ======== Other buttons ========================
     } else if (uniqueKey === 'makeSmaller') {
       this.decreaseSize();
-      this.updateGalleryWidthMeasurement();
     } else if (uniqueKey === 'makeLarger') {
       this.increaseSize();
-      this.updateGalleryWidthMeasurement();
     } else if (uniqueKey === 'startWizard') {
       this.startWizard();
     } else if (uniqueKey === 'clearHistory') {
@@ -968,7 +965,7 @@ export class HomeComponent implements OnInit, AfterViewInit {
       if (uniqueKey === 'hideSidebar') {
         setTimeout(() => {
           this.virtualScroller.refresh();
-          this.updateGalleryWidthMeasurement();
+          this.computePreviewWidth();
         }, 300);
       }
     }
@@ -1065,9 +1062,7 @@ export class HomeComponent implements OnInit, AfterViewInit {
    * Decrease preview size
    */
   public decreaseSize(): void {
-    if (this.currentViewImgHeight > 100) {
-      this.currentViewImgHeight = this.currentViewImgHeight - 36;
-    }
+    this.currentViewPerRow++;
     this.computePreviewWidth();
   }
 
@@ -1075,9 +1070,7 @@ export class HomeComponent implements OnInit, AfterViewInit {
    * Increase preview size
    */
   public increaseSize(): void {
-    if (this.currentViewImgHeight < 500) {
-      this.currentViewImgHeight = this.currentViewImgHeight + 36;
-    }
+    this.currentViewPerRow--;
     this.computePreviewWidth();
   }
 
@@ -1088,7 +1081,9 @@ export class HomeComponent implements OnInit, AfterViewInit {
     if (   this.appState.currentView === 'showClips'
         || this.appState.currentView === 'showThumbnails'
         || this.appState.currentView === 'showDetails') {
-      this.previewWidth = this.currentViewImgHeight * (16 / 9);
+      this.updateGalleryWidthMeasurement();
+      this.previewWidth = (this.galleryWidth / this.currentViewPerRow) - 40; // 40px margin
+      this.currentViewImgHeight = this.previewWidth * (9 / 16);
     }
   }
 
@@ -1096,7 +1091,7 @@ export class HomeComponent implements OnInit, AfterViewInit {
    * Compute and update the galleryWidth
    */
   public updateGalleryWidthMeasurement(): void {
-    this.galleryWidth = document.getElementById('scrollDiv').getBoundingClientRect().width;
+    this.galleryWidth = document.getElementById('scrollDiv').getBoundingClientRect().width - 20;
   }
 
   /**

--- a/src/app/components/home/home.component.ts
+++ b/src/app/components/home/home.component.ts
@@ -1083,7 +1083,8 @@ export class HomeComponent implements OnInit, AfterViewInit {
         || this.appState.currentView === 'showThumbnails'
         || this.appState.currentView === 'showDetails') {
       this.previewWidth = (this.galleryWidth / this.currentViewPerRow) - 40; // 40px margin
-    } else if ( this.appState.currentView === 'showFilmstrip' ) {
+    } else if ( this.appState.currentView === 'showFilmstrip'
+             || this.appState.currentView === 'showFullView' ) {
       this.previewWidth = ((this.galleryWidth - 30) / this.currentViewPerRow);
     }
     this.currentViewImgHeight = this.previewWidth * (9 / 16);

--- a/src/app/components/home/home.component.ts
+++ b/src/app/components/home/home.component.ts
@@ -1078,13 +1078,15 @@ export class HomeComponent implements OnInit, AfterViewInit {
    * Computes the preview width for thumbnails view
    */
   public computePreviewWidth(): void {
+    this.updateGalleryWidthMeasurement();
     if (   this.appState.currentView === 'showClips'
         || this.appState.currentView === 'showThumbnails'
         || this.appState.currentView === 'showDetails') {
-      this.updateGalleryWidthMeasurement();
       this.previewWidth = (this.galleryWidth / this.currentViewPerRow) - 40; // 40px margin
-      this.currentViewImgHeight = this.previewWidth * (9 / 16);
+    } else if ( this.appState.currentView === 'showFilmstrip' ) {
+      this.previewWidth = ((this.galleryWidth - 30) / this.currentViewPerRow);
     }
+    this.currentViewImgHeight = this.previewWidth * (9 / 16);
   }
 
   /**


### PR DESCRIPTION
This PR implements #71, which is to zoom by an integer number of images/thumbnails per row! This allows the app to always use the full space available to it for displaying items! 👍 

This also fixes the issue from #95 in a nicer way! 🎉 

This PR is going to supersede #160, as I've integrated that change into this one! 😄  