### PR TITLE
Update ngx-virtual-scroller

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@ffmpeg-installer/ffmpeg": "1.0.17",
     "@ffprobe-installer/ffprobe": "1.0.9",
     "@ngx-translate/core": "11.0.1",
-    "ngx-virtual-scroller": "1.0.16"
+    "ngx-virtual-scroller": "2.0.7"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "0.13.1",

--- a/src/app/components/home/details/details.component.scss
+++ b/src/app/components/home/details/details.component.scss
@@ -1,10 +1,10 @@
 .filmstrip-container {
   display: inline-block;
-  margin: 20px 20px 0;
+  min-height: 170px;
   overflow: hidden;
+  padding: 20px 20px 0; // because ngx-virtual-scroll ignores `margin` but not `padding`
   transition-property: height;
   transition: 300ms;
-  min-height: 170px;
   width: calc(100% - 40px);
 }
 

--- a/src/app/components/home/filmstrip/filmstrip.component.scss
+++ b/src/app/components/home/filmstrip/filmstrip.component.scss
@@ -1,5 +1,5 @@
 .meta-container {
-  margin: 20px 20px 5px;
+  padding: 20px 20px 5px; // because ngx-virtual-scroll ignores `margin` but not `padding`
   transition-property: height;
   transition: 300ms;
   width: calc(100% - 40px);

--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -887,8 +887,9 @@
       <ng-container *ngIf="appState.currentView === 'showThumbnails'">
         <app-gallery-item
           *ngFor="let item of scroll.viewPortItems"
-          (contextmenu)="(item.cleanName === '***') ? doNothing() : rightMouseClicked($event, item)"
+
           (click)="(item.cleanName === '***') ? handleFolderWordClicked(item.partialPath) : handleClick($event, item)"
+          (contextmenu)="(item.cleanName === '***') ? doNothing() : rightMouseClicked($event, item)"
 
           [elHeight]="currentViewImgHeight + textPaddingHeight"
           [elWidth]="previewWidth"
@@ -904,12 +905,15 @@
           [randomImage]="settingsButtons['randomImage'].toggled"
           [returnToFirstScreenshot]="settingsButtons['returnToFirstScreenshot'].toggled"
           [showMeta]="settingsButtons['showMoreInfo'].toggled"
+
+          style="display: inline-block"
         ></app-gallery-item>
       </ng-container>
 
       <ng-container *ngIf="appState.currentView === 'showFilmstrip'">
         <app-filmstrip-item
           *ngFor="let item of scroll.viewPortItems"
+
           (click)="handleClick($event, item)"
           (contextmenu)="rightMouseClicked($event, item)"
 
@@ -924,12 +928,15 @@
           [hoverScrub]="settingsButtons['hoverScrub'].toggled"
           [largerFont]="settingsButtons['fontSizeLarger'].toggled"
           [showMeta]="settingsButtons['showMoreInfo'].toggled"
+
+          style="display: block"
         ></app-filmstrip-item>
       </ng-container>
 
       <ng-container *ngIf="appState.currentView === 'showFullView'">
         <app-full-item
           *ngFor="let item of scroll.viewPortItems"
+
           (click)="handleClick($event, item)"
           (contextmenu)="rightMouseClicked($event, item)"
 
@@ -944,20 +951,25 @@
           [darkMode]="settingsButtons['darkMode'].toggled"
           [largerFont]="settingsButtons['fontSizeLarger'].toggled"
           [showMeta]="settingsButtons['showMoreInfo'].toggled"
+
+          style="display: block"
         ></app-full-item>
       </ng-container>
 
       <ng-container *ngIf="appState.currentView === 'showFiles'">
         <app-file-item
           *ngFor="let item of scroll.viewPortItems"
-          (contextmenu)="(item.cleanName === '***') ? doNothing() : rightMouseClicked($event, item)"
+
           (click)="(item.cleanName === '***') ? handleFolderWordClicked(item.partialPath) : openVideo(item.index)"
+          (contextmenu)="(item.cleanName === '***') ? doNothing() : rightMouseClicked($event, item)"
 
           [video]="item"
 
           [largerFont]="settingsButtons['fontSizeLarger'].toggled"
           [showMeta]="settingsButtons['showMoreInfo'].toggled"
           [darkMode]="settingsButtons['darkMode'].toggled"
+
+          style="display: block"
         ></app-file-item>
       </ng-container>
 
@@ -965,8 +977,8 @@
         <app-clip-item
           *ngFor="let item of scroll.viewPortItems"
 
-          (contextmenu)="(item.cleanName === '***') ? doNothing() : rightMouseClicked($event, item)"
           (click)="(item.cleanName === '***') ? handleFolderWordClicked(item.partialPath) : handleClick($event, item)"
+          (contextmenu)="(item.cleanName === '***') ? doNothing() : rightMouseClicked($event, item)"
 
           [video]="item"
 
@@ -980,6 +992,8 @@
           [darkMode]="settingsButtons['darkMode'].toggled"
           [largerFont]="settingsButtons['fontSizeLarger'].toggled"
           [showMeta]="settingsButtons['showMoreInfo'].toggled"
+
+          style="display: inline-block"
         ></app-clip-item>
       </ng-container>
 
@@ -1013,6 +1027,8 @@
           [showManualTags]="settingsButtons['manualTags'].toggled"
           [showAutoFileTags]="settingsButtons['autoFileTags'].toggled"
           [showAutoFolderTags]="settingsButtons['autoFolderTags'].toggled"
+
+          style="display: block"
         ></app-details-item>
       </ng-container>
 


### PR DESCRIPTION
Update the `ngx-virtual-scroller` dependency and fix up a major scrolling issue we're experiencing currently in _master_:
- Thumbnail view will now add/remove elements as you scroll

There is still some jankiness when scrolling some views, resizing doesn't always seem to update the height for virtual scroller, so I'll create follow-up commits or other branches to fix those 👍 