### PR TITLE
Actually quit the app

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -154,10 +154,6 @@ try {
     // }
   });
 
-  app.on('before-quit', (event) => {
-    event.preventDefault();
-  });
-
   app.on('activate', () => {
     // On OS X it's common to re-create a window in the app when the
     // dock icon is clicked and there are no other windows open.


### PR DESCRIPTION
This PR just removes a function that prevented the app from ever actually closing when you quit! 👎 

I think it was added to allow `cmd+q` to process, but this is already in the keycode handling, and it doesn't seem to be required here anymore! 😄 