### PR TITLE
Fix EMFILE: too many open files bug

### DIFF
--- a/main-support.ts
+++ b/main-support.ts
@@ -631,7 +631,7 @@ function hashFile(pathToFile: string): string {
     fs.readSync(fd, data, 0, sampleSize, 0);                                  // read beginning of file
     fs.readSync(fd, data, sampleSize, sampleSize, fileSize / 2);              // read middle of file
     fs.readSync(fd, data, sampleSize * 2, sampleSize, fileSize - sampleSize); // read end of file
-    fs.close(fd);
+    fs.closeSync(fd);  // if you don't close, you get `EMFILE: too many open files` error
   }
 
   // append the file size to the data

--- a/main-support.ts
+++ b/main-support.ts
@@ -631,7 +631,6 @@ function hashFile(pathToFile: string): string {
     fs.readSync(fd, data, 0, sampleSize, 0);                                  // read beginning of file
     fs.readSync(fd, data, sampleSize, sampleSize, fileSize / 2);              // read middle of file
     fs.readSync(fd, data, sampleSize * 2, sampleSize, fileSize - sampleSize); // read end of file
-    fs.close();
   }
 
   // append the file size to the data

--- a/main-support.ts
+++ b/main-support.ts
@@ -631,6 +631,7 @@ function hashFile(pathToFile: string): string {
     fs.readSync(fd, data, 0, sampleSize, 0);                                  // read beginning of file
     fs.readSync(fd, data, sampleSize, sampleSize, fileSize / 2);              // read middle of file
     fs.readSync(fd, data, sampleSize * 2, sampleSize, fileSize - sampleSize); // read end of file
+    fs.close(fd);
   }
 
   // append the file size to the data

--- a/main-support.ts
+++ b/main-support.ts
@@ -613,28 +613,26 @@ function updateArrayWithHashes(
 }
 
 /**
- * Hash a given file using it's file name and size
- * md5(file.name + file.size)
- * @param fileName  -- file name to hash
- * @param fileSize  -- file size to hash
+ * Hash a given file using its size
+ * @param pathToFile  -- path to file
  */
-function hashFile(file: string): string {
+function hashFile(pathToFile: string): string {
   const sampleSize = 16 * 1024;
   const sampleThreshold = 128 * 1024;
-  const stats = fs.statSync(file);
+  const stats = fs.statSync(pathToFile);
   const fileSize = stats.size;
 
   let data: Buffer;
   if (fileSize < sampleThreshold) {
-    data = fs.readFileSync(file); // too small, just read the whole file
+    data = fs.readFileSync(pathToFile); // too small, just read the whole file
   } else {
     data = Buffer.alloc(sampleSize * 3);
-    const fd = fs.openSync(file, 'r');
+    const fd = fs.openSync(pathToFile, 'r');
     fs.readSync(fd, data, 0, sampleSize, 0);                                  // read beginning of file
     fs.readSync(fd, data, sampleSize, sampleSize, fileSize / 2);              // read middle of file
     fs.readSync(fd, data, sampleSize * 2, sampleSize, fileSize - sampleSize); // read end of file
+    fs.close();
   }
-
 
   // append the file size to the data
   const buf = Buffer.concat([data, Buffer.from(fileSize.toString())]);


### PR DESCRIPTION
On _Windows_ after importing about 8000 files (during the initial hashing phase) the app would crash with 
```
EMFILE: too many open files
```
This PR fixes the problem by closing all the `fs.readSync` 🙆‍♂ 