### PR TITLE
Handle folders with spaces

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -302,7 +302,7 @@ function openThisDamnFile(pathToVhaFile: string) {
         'finalObjectReturning',
         lastSavedFinalObject,
         pathToVhaFile,
-        globals.selectedOutputFolder + path.sep,   // app needs the trailing slash (at least for now)
+        getHtmlPath(globals.selectedOutputFolder),
         changedRootFolder,
         rootFolderLive
       );
@@ -310,6 +310,28 @@ function openThisDamnFile(pathToVhaFile: string) {
   });
 }
 
+/**
+ * Return an HTML string for a path to the `vha` file
+ * e.g. `C:\Some folder` becomes `C:/Some%20folder`
+ * @param anyOsPath
+ */
+function getHtmlPath(anyOsPath: string): string {
+      // Windows was misbehaving
+      // so we normalize the path (just in case) and replace all `\` with `/` in this instance
+      // because at this point Electron will be showing images following the path provided
+      // with the `file:///` protocol -- seems to work
+      const normalizedPath: string = path.normalize(anyOsPath);
+      const forwardSlashes: string = normalizedPath.replace(/\\/g, '/');
+      return forwardSlashes.replace(/ /g, '%20');
+}
+
+/**
+ * Update 3 globals:
+ *  - hubName
+ *  - screenshotSettings
+ *  - selectedSourceFolder
+ * @param vhaFileContents
+ */
 function setGlobalsFromVhaFile(vhaFileContents: FinalObject) {
   globals.hubName = vhaFileContents.hubName,
   globals.screenshotSettings = vhaFileContents.screenshotSettings;


### PR DESCRIPTION
Bugfix for Windows:
- handle opening `vha` files from paths that include folders with spaces 😱 

Huge thank you to @cal2195 for diagnosing the problem and finding a solution (see #131)

Closes #131 

⚠️ Seems to create a new bug -- when creating a new _hub_ the previews are black until you exit the app and re-open it. I think it should be a quick fix -- though I might do it later (it's late tonight 😴 )