### PR TITLE
mute works across all clip view variations

### DIFF
--- a/src/app/components/home/clip/clip.component.html
+++ b/src/app/components/home/clip/clip.component.html
@@ -20,6 +20,7 @@
     [src]="'file://' + folderPath + '/' + folderThumbPaths[0]"
     [poster]="sanitizer.bypassSecurityTrustUrl('file://' + folderPath + '/' + folderPosterPaths[0])"
     class="mini-video-thumb"
+    [volume]="forceMute ? 0 : 1"
     onmouseover="this.play().catch((err) => {this.load()})"
     onmouseout="this.pause()"
     loop
@@ -29,6 +30,7 @@
     [src]="'file://' + folderPath + '/' + folderThumbPaths[1]"
     [poster]="sanitizer.bypassSecurityTrustUrl('file://' + folderPath + '/' + folderPosterPaths[1])"
     class="mini-video-thumb"
+    [volume]="forceMute ? 0 : 1"
     style="left: 50%"
     onmouseover="this.play().catch((err) => {this.load()})"
     onmouseout="this.pause()"
@@ -39,6 +41,7 @@
     [src]="'file://' + folderPath + '/' + folderThumbPaths[2]"
     [poster]="sanitizer.bypassSecurityTrustUrl('file://' + folderPath + '/' + folderPosterPaths[2])"
     class="mini-video-thumb"
+    [volume]="forceMute ? 0 : 1"
     style="top: 50%"
     onmouseover="this.play().catch((err) => {this.load()})"
     onmouseout="this.pause()"
@@ -49,16 +52,18 @@
     [src]="'file://' + folderPath + '/' + folderThumbPaths[3]"
     [poster]="sanitizer.bypassSecurityTrustUrl('file://' + folderPath + '/' + folderPosterPaths[3])"
     class="mini-video-thumb"
+    [volume]="forceMute ? 0 : 1"
     style="left: 50%; top: 50%"
     onmouseover="this.play().catch((err) => {this.load()})"
     onmouseout="this.pause()"
     loop
   ></video>
   <video
-    *ngIf="noError && autoplay && folderThumbPaths[0]"
+    *ngIf="noError && autoplay && appInFocus && folderThumbPaths[0]"
     [src]="'file://' + folderPath + '/' + folderThumbPaths[0]"
     [poster]="sanitizer.bypassSecurityTrustUrl('file://' + folderPath + '/' + folderPosterPaths[0])"
     class="mini-video-thumb"
+    [volume]="forceMute ? 0 : 1"
     onmouseover="this.muted = false;"
     onmouseout="this.muted = true;"
     onloadstart="this.muted = true;"
@@ -66,10 +71,11 @@
     autoplay
   ></video>
   <video
-    *ngIf="noError && autoplay && folderThumbPaths[1]"
+    *ngIf="noError && autoplay && appInFocus && folderThumbPaths[1]"
     [src]="'file://' + folderPath + '/' + folderThumbPaths[1]"
     [poster]="sanitizer.bypassSecurityTrustUrl('file://' + folderPath + '/' + folderPosterPaths[1])"
     class="mini-video-thumb"
+    [volume]="forceMute ? 0 : 1"
     style="left: 50%"
     onmouseover="this.muted = false;"
     onmouseout="this.muted = true;"
@@ -78,10 +84,11 @@
     autoplay
   ></video>
   <video
-    *ngIf="noError && autoplay && folderThumbPaths[2]"
+    *ngIf="noError && autoplay && appInFocus && folderThumbPaths[2]"
     [src]="'file://' + folderPath + '/' + folderThumbPaths[2]"
     [poster]="sanitizer.bypassSecurityTrustUrl('file://' + folderPath + '/' + folderPosterPaths[2])"
     class="mini-video-thumb"
+    [volume]="forceMute ? 0 : 1"
     style="top: 50%"
     onmouseover="this.muted = false;"
     onmouseout="this.muted = true;"
@@ -90,10 +97,11 @@
     autoplay
   ></video>
   <video
-    *ngIf="noError && autoplay && folderThumbPaths[3]"
+    *ngIf="noError && autoplay && appInFocus && folderThumbPaths[3]"
     [src]="'file://' + folderPath + '/' + folderThumbPaths[3]"
     [poster]="sanitizer.bypassSecurityTrustUrl('file://' + folderPath + '/' + folderPosterPaths[3])"
     class="mini-video-thumb"
+    [volume]="forceMute ? 0 : 1"
     style="left: 50%; top: 50%"
     onmouseover="this.muted = false;"
     onmouseout="this.muted = true;"
@@ -133,13 +141,14 @@
     [ngStyle]="{ 'height': imgHeight + 'px' }"
     (click)="videoClick.emit($event)"
     class="screencap"
+    [volume]="forceMute ? 0 : 1"
     onmouseover="this.play().catch((err) => {this.load()})"
     onmouseout="this.pause()"
     loop
   ></video>
 
   <video
-    *ngIf="noError && autoplay"
+    *ngIf="noError && autoplay && appInFocus"
     [src]="'file://' + folderPath + '/' + pathToVideo"
     [poster]="sanitizer.bypassSecurityTrustUrl('file://' + folderPath + '/' + poster)"
     [ngStyle]="{ 'height': imgHeight + 'px' }"

--- a/src/app/components/home/clip/clip.component.ts
+++ b/src/app/components/home/clip/clip.component.ts
@@ -1,4 +1,4 @@
-import { Component, HostListener, Input, Output, EventEmitter, OnInit } from '@angular/core';
+import { Component, HostListener, Input, Output, EventEmitter, OnInit, ChangeDetectorRef } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
 
 import { ImageElement } from '../../common/final-object.interface';
@@ -31,6 +31,7 @@ export class ClipComponent implements OnInit {
   @Input() forceMute: boolean;
   @Input() showMeta: boolean;
 
+  appInFocus: boolean = true;
   folderPosterPaths: string[] = [];
   folderThumbPaths: string[] = [];
   hover: boolean;
@@ -39,14 +40,23 @@ export class ClipComponent implements OnInit {
   poster: string;
 
   constructor(
-    public sanitizer: DomSanitizer
+    public sanitizer: DomSanitizer,
+    public cd: ChangeDetectorRef
   ) { }
 
   @HostListener('mouseenter') onMouseEnter() {
-      this.hover = true;
+    this.hover = true;
   }
   @HostListener('mouseleave') onMouseLeave() {
-      this.hover = false;
+    this.hover = false;
+  }
+  @HostListener('window:blur', ['$event'])
+  onBlur(event: any): void {
+    this.appInFocus = false;
+  }
+  @HostListener('window:focus', ['$event'])
+  onFocus(event: any): void {
+    this.appInFocus = true;
   }
 
   ngOnInit() {


### PR DESCRIPTION
Mute toggle now mutes all sounds from every clip preview type
- regular clip
- regular clip (autoplay enabled)
- folder of clips
- folder of clips (autoplay enabled)

If _autoplay_ is enabled, the videos stop playing if windows loses focus (happens whenever minimizing the app) and restarts playing when window regains focus. 
- as a side-effect, at the moment, clicking into another window stops the auto-play (could be good behavior), but it's implemented that all the previews become black (rather than going back to preview images). I can fix that later.

Closes #115 