### PR TITLE
Duration filter improvement

### DIFF
--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -701,10 +701,10 @@
       <!-- star filter & its frequency histogram -->
       <div *ngIf="settingsButtons['starFilter'].toggled" class="resolutionFilterContainer">
         <div class="frequencyGraphContainerStar">
-          <ng-container *ngFor="let resolution of starRatingFreqArr; index as i">
+          <ng-container *ngFor="let starRating of starRatingFreqArr; index as i">
             <div
               [ngClass]="{ resDisabled: (i < starLeftBound) || (i >= starRightBound) }"
-              [ngStyle]="{ height: resolution + '%' }"
+              [ngStyle]="{ height: starRating + '%' }"
               class="frequency-bar-star"
             >
             </div>
@@ -789,7 +789,7 @@
 
       <!-- total found -->
       <div class="filteringTotal">
-        <span>{{ currResults.total }} {{ 'SIDEBAR.found' | translate }}</span>
+        <span>{{ currResults.total | number:'.0' }} {{ 'SIDEBAR.found' | translate }}</span>
       </div>
 
       <!-- word cloud -->

--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -663,9 +663,9 @@
           (newSliderFilterSelected)="newLengthFilterSelected($event)"
           [darkMode]="settingsButtons['darkMode'].toggled"
           [labelFormatPipe]="'lengthPipe'"
-          [maximumValue]="longest"
+          [maximumValue]="durationOutlierCutoff"
           [minimumValue]="0"
-          [showLabels]="true"
+          [lengthFilter]="true"
           [steps]="50"
         ></app-slider-filter>
       </div>

--- a/src/app/components/home/home.component.ts
+++ b/src/app/components/home/home.component.ts
@@ -257,7 +257,7 @@ export class HomeComponent implements OnInit, AfterViewInit {
   manualTagFilterString: string = '';
   manualTagShowFrequency: boolean = true;
 
-  longest: number = 0;
+  longest: number = 0; // longest duration of all the video files -- only used in the Duration Filter
 
   // ========================================================================
   // Please add new variables below if they don't fit into any other section

--- a/src/app/components/home/slider-filter/slider-filter.component.html
+++ b/src/app/components/home/slider-filter/slider-filter.component.html
@@ -42,7 +42,7 @@
     </div>
   </div>
   <span
-    *ngIf="showLabels"
+    *ngIf="lengthFilter"
     class="leftLabel"
     [ngStyle]="{
       left: ((currentXleft > 35) ? currentXleft - 35 : 0) + 'px'
@@ -51,7 +51,7 @@
     {{ convertToIndex(currentXleft) | wrapperPipe : labelFormatPipe }}
   </span>
   <span
-    *ngIf="showLabels"
+    *ngIf="lengthFilter"
     class="rightLabel"
     [ngStyle]="{
       right: 160 - ((currentXright < 125) ? currentXright + 35 : 160) + 'px'
@@ -59,6 +59,6 @@
   >
     {{ convertToIndex(currentXright) | wrapperPipe : labelFormatPipe }}
   </span>
-  <span *ngIf="showLabels" class="minLabel">0 min</span>
-  <span *ngIf="showLabels" class="maxLabel">{{ maximumValue | wrapperPipe : labelFormatPipe }}</span>
+  <span *ngIf="lengthFilter" class="minLabel">0 min</span>
+  <span *ngIf="lengthFilter" class="maxLabel">∞</span>
 </div>

--- a/src/app/components/home/slider-filter/slider-filter.component.scss
+++ b/src/app/components/home/slider-filter/slider-filter.component.scss
@@ -114,6 +114,7 @@
 .maxLabel {
   color: $gray-50;
   float: right;
-  font-size: 10px;
-  margin-top: 40px;
+  font-size: 18px;
+  margin-top: 30px;
+  transform: translate(-4px, 5px);
 }

--- a/src/app/components/home/slider-filter/slider-filter.component.ts
+++ b/src/app/components/home/slider-filter/slider-filter.component.ts
@@ -11,7 +11,7 @@ export class SliderFilterComponent implements OnInit, OnDestroy {
   @Input() minimumValue: number;
   @Input() maximumValue: number;
   @Input() steps: number;
-  @Input() showLabels?: boolean = false;
+  @Input() lengthFilter?: boolean = false;
   @Input() labelFormatPipe?: string;
 
   @Output() newSliderFilterSelected = new EventEmitter<number[]>();
@@ -81,7 +81,14 @@ export class SliderFilterComponent implements OnInit, OnDestroy {
    * @param value
    */
   convertToIndex(value: number): number {
-    return (value / this.width) * (this.maximumValue - this.minimumValue) + this.minimumValue;
+
+    const cutoff = (value / this.width) * (this.maximumValue - this.minimumValue) + this.minimumValue;
+
+    if (this.lengthFilter && cutoff > this.maximumValue) {
+      return Infinity;
+    } else {
+      return cutoff;
+    }
   }
 
   /**

--- a/src/app/components/home/statistics/statistics.component.html
+++ b/src/app/components/home/statistics/statistics.component.html
@@ -17,12 +17,12 @@
     </tr>
     <tr>
       <td>{{ 'STATISTICS.numOfFiles' | translate }}</td>
-      <td class="rightCol">{{ totalFiles }}</td>
+      <td class="rightCol">{{ totalFiles | number:'.0' }}</td>
     </tr>
 
     <tr>
       <td>{{ 'STATISTICS.numOfFolders' | translate }}</td>
-      <td class="rightCol">{{ numFolders }}</td>
+      <td class="rightCol">{{ numFolders | number:'.0' }}</td>
     </tr>
 
     <tr>

--- a/src/app/components/pipes/length.pipe.ts
+++ b/src/app/components/pipes/length.pipe.ts
@@ -15,6 +15,8 @@ export class LengthPipe implements PipeTransform {
   transform(numOfSec: number, omitSeconds?: boolean, printHrMin?: boolean): string {
     if (numOfSec === undefined) {
       return '';
+    } else if (numOfSec === Infinity) {
+      return 'every';
     } else {
       const hh = (Math.floor(numOfSec / 3600)).toString();
       const mm = (Math.floor(numOfSec / 60) % 60).toString();

--- a/src/app/components/pipes/sorting.pipe.ts
+++ b/src/app/components/pipes/sorting.pipe.ts
@@ -52,7 +52,7 @@ export class SortingPipe implements PipeTransform {
    */
   transform(galleryArray: ImageElement[], sortingType: SortType, forceSortUpdateHack: number): ImageElement[] {
 
-    console.log('SORTING RUNNING');
+    // console.log('SORTING RUNNING'); // ENABLE AND CHECK IF IT RUNS TOO OFTEN !!!
 
     if (sortingType === 'random') {
       let currentIndex = (galleryArray[0].index === -1 ? 1 : 0); // skip 'up button' if present
@@ -136,7 +136,7 @@ export class SortingPipe implements PipeTransform {
       });
       return sorted.slice(0);
     } else {
-      console.log('default sort');
+      // console.log('default sort'); // TODO -- Re-enable and optimize!
       const sorted = galleryArray.sort((x: ImageElement, y: ImageElement): any => {
         return this.sortFunctionLol(x, y, 'index', true);
       });

--- a/src/app/components/pipes/star-filter.service.ts
+++ b/src/app/components/pipes/star-filter.service.ts
@@ -62,7 +62,7 @@ export class StarFilterService {
       }
     });
     if (first > max) {
-      this.frequencyMap.set(0.5, max + 1);
+      this.frequencyMap.set(0.5, max);
     }
 
     const scalar = 100 / max;


### PR DESCRIPTION
Duration filter now spans from lowest to the `durationOutlierCutoff`, advancing the slider to the right-most position shows "every" (not i18n translated yet 😓 -- might not be in 2.0.0 since it's not straightforward and I'd rather fix other things first).

The cutoff is computed as 3 * IQR (Inter Quartile Range). This makes for a better duration filter experience, at least in my case 😅 @cal2195 -- if you have time, please let me know how it looks in your library 👍 

As a bonus, this PR fixes the CSS on the _star filter_ 💯 (was very easy, though it created a minor bug where `N/A` column doesn't show up any more sometimes 🤷‍♂ still way better than before 👍 

Closes #132 