### PR TITLE
Similar video improvements

### DIFF
--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -561,7 +561,14 @@
 
     <div
       [ngClass]="{ 'sidebar-hidden': settingsButtons['hideSidebar'].toggled }"
-      [ngStyle]="{ 'background': settingsButtons['darkMode'].toggled ? '#444444' : '#d8d8d8' }"
+      [ngStyle]="{
+                    'height': 'calc(100vh - ' + (
+                                                  (settingsButtons['hideTop'].toggled ? 53 : 98)
+                                                + (appState.menuHidden ? -32 : 0)
+                                                + (settingsButtons['showRelatedVideosTray'].toggled ? 160 : 0)
+                                                                                                                ) + 'px)',
+                    'background': settingsButtons['darkMode'].toggled ? '#444444' : '#d8d8d8'
+                 }"
       class="sidebar"
       #searchRef
     >
@@ -831,8 +838,11 @@
       id="scrollDiv"
       class="gallery-container"
       [ngStyle]="{
-          'height': 'calc(100vh - ' + ((settingsButtons['hideTop'].toggled ? 53 : 98)
-                      + (appState.menuHidden ? -32 : 0)) + 'px)',
+          'height': 'calc(100vh - ' + (
+                                          (settingsButtons['hideTop'].toggled ? 53 : 98)
+                                        + (appState.menuHidden ? -32 : 0)
+                                        + (settingsButtons['showRelatedVideosTray'].toggled ? 170 : 0)
+                                                                                                        ) + 'px)',
           'background': settingsButtons['darkMode'].toggled ? '#000000' : '#999999'
         }"
       [enableUnequalChildrenSizes]="appState.currentView === 'showFullView'"

--- a/src/app/components/home/layout.scss
+++ b/src/app/components/home/layout.scss
@@ -249,7 +249,9 @@ $sidebar-width: 190px;
 
 .most-similar-tray {
   box-sizing: border-box;
-  height: 150px;
+  // height - must be same as the hardcoded value in <virtual-scroller> height property
+  //          & close to the .sidebar <div> `ngStyle` height property
+  height: 170px;
   padding-top: 0;
 
   .most-similar-comment {


### PR DESCRIPTION
When _similar videos_ is shown, the panel no longer _obstructs_ the gallery & sidebar - just decreases their view area. Both can be scrolled to the bottom without problems now 👍 

Closes #179 