### PR TITLE
normalize path before open

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -402,7 +402,7 @@ ipc.on('just-started', function (event, someMessage) {
  * Open a particular video file clicked inside Angular
  */
 ipc.on('openThisFile', function (event, fullFilePath) {
-  shell.openItem(fullFilePath);
+  shell.openItem(path.normalize(fullFilePath)); // normalize because on windows, the path sometimes is mixing `\` and `/`
 });
 
 /**


### PR DESCRIPTION
Was erroring out on _Windows_ when trying to open a path - because the file included a mix of `\` and `/` 😞 

Now fixed 👌 