### PR TITLE
no clips extracted message when appropriate

### DIFF
--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -1010,31 +1010,6 @@
         ></app-file-item>
       </ng-container>
 
-      <ng-container *ngIf="appState.currentView === 'showClips'">
-        <app-clip-item
-          *ngFor="let item of scroll.viewPortItems"
-          (videoClick)="(item.cleanName === '***') ? handleFolderWordClicked(item.partialPath) : handleClick($event, item)"
-          (sheetClick)="this.openThumbnailSheet(item)"
-          (contextmenu)="(item.cleanName === '***') ? doNothing() : rightMouseClicked($event, item)"
-
-          [video]="item"
-
-          [elHeight]="previewHeight + textPaddingHeight"
-          [elWidth]="previewWidth"
-          [folderPath]="appState.selectedOutputFolder"
-          [hubName]="appState.hubName"
-          [imgHeight]="previewHeight"
-
-          [autoplay]="settingsButtons['autoplayClips'].toggled"
-          [darkMode]="settingsButtons['darkMode'].toggled"
-          [largerFont]="settingsButtons['fontSizeLarger'].toggled"
-          [forceMute]="settingsButtons['muteClips'].toggled"
-          [showMeta]="settingsButtons['showMoreInfo'].toggled"
-
-          style="display: inline-block"
-        ></app-clip-item>
-      </ng-container>
-
       <ng-container *ngIf="appState.currentView === 'showDetails'">
         <app-details-item
           *ngFor="let item of scroll.viewPortItems"
@@ -1069,6 +1044,37 @@
 
           style="display: block"
         ></app-details-item>
+      </ng-container>
+
+      <ng-container *ngIf="appState.currentView === 'showClips' && currentScreenshotSettings.clipSnippets > 0">
+        <app-clip-item
+          *ngFor="let item of scroll.viewPortItems"
+          (videoClick)="(item.cleanName === '***') ? handleFolderWordClicked(item.partialPath) : handleClick($event, item)"
+          (sheetClick)="this.openThumbnailSheet(item)"
+          (contextmenu)="(item.cleanName === '***') ? doNothing() : rightMouseClicked($event, item)"
+
+          [video]="item"
+
+          [elHeight]="previewHeight + textPaddingHeight"
+          [elWidth]="previewWidth"
+          [folderPath]="appState.selectedOutputFolder"
+          [hubName]="appState.hubName"
+          [imgHeight]="previewHeight"
+
+          [autoplay]="settingsButtons['autoplayClips'].toggled"
+          [darkMode]="settingsButtons['darkMode'].toggled"
+          [largerFont]="settingsButtons['fontSizeLarger'].toggled"
+          [forceMute]="settingsButtons['muteClips'].toggled"
+          [showMeta]="settingsButtons['showMoreInfo'].toggled"
+
+          style="display: inline-block"
+        ></app-clip-item>
+      </ng-container>
+
+      <ng-container *ngIf="appState.currentView === 'showClips' && currentScreenshotSettings.clipSnippets === 0">
+        <span class="no-clips-message" [ngStyle]="{ color: settingsButtons['darkMode'].toggled ? 'white' : 'black' }">
+          {{ 'SETTINGS.noClipsExtracted' | translate }}
+        </span>
       </ng-container>
 
     </virtual-scroller>

--- a/src/app/components/home/layout.scss
+++ b/src/app/components/home/layout.scss
@@ -271,6 +271,11 @@ $sidebar-width: 190px;
   }
 }
 
+.no-clips-message {
+  display: block;
+  margin: 100px 0 0;
+  text-align: center;
+}
 
 // TODO -- keep DRY -- this is taken from `inputFilter`
 .manual-tag-tray-filter {

--- a/src/app/i18n/en.ts
+++ b/src/app/i18n/en.ts
@@ -161,6 +161,7 @@ export const English = {
     hideTopBar        :'Hide top bar',
     manualTags        :'Manual tag settings',
     miscView          :'Miscellaneous view settings',
+    noClipsExtracted  :'No clips extracted',
     otherSettings     :'Create a new hub',
     relatedVideosTray :'Related videos',
     reloadUpdate      :'Reload / update hub',


### PR DESCRIPTION
Closes #204 

I decided not to hide the button (not an intuitive experience when you can't find what you expect to be there) -- there's just a message now in the _clips view_ gallery that says "no clips extracted" 👌 

ps - code-block moved down, but nothing changed except the `*ngIf`