### PR TITLE
remove prediction, improve wizard

### DIFF
--- a/src/app/components/home.component.html
+++ b/src/app/components/home.component.html
@@ -1238,6 +1238,8 @@
     <app-icon class="close-modal-icon" [icon]="'icon-close'"></app-icon>
   </div>
 
+  <div class="gradient-to-indicate-scrolling"></div>
+
   <div class="left-side" @slowFadeIn>
 
     <h2>{{ 'WIZARD.openPrevious' | translate }}</h2>
@@ -1526,6 +1528,7 @@
     </div>
 
     <div
+      style="margin-top: 30px;"
       [ngClass]="{
         'current-step': wizard.selectedOutputFolder !== ''
                      && wizard.selectedSourceFolder !== ''
@@ -1535,6 +1538,7 @@
       5
     </div>
     <button
+      style="margin-top: 45px;"
       class="wizardButton"
       [disabled]="wizard.selectedOutputFolder === ''
                || wizard.selectedSourceFolder === ''
@@ -1545,7 +1549,7 @@
     >
       {{ 'WIZARD.createVideoHub' | translate }}
     </button>
-
+<!--
     <span
       class="description"
       *ngIf="wizard.totalNumberOfFiles !== -1"
@@ -1570,6 +1574,7 @@
       </span>
       {{ 'WIZARD.sizeToImport' | translate }}
     </span>
+-->
 
   </div>
 

--- a/src/app/components/home.component.ts
+++ b/src/app/components/home.component.ts
@@ -477,10 +477,10 @@ export class HomeComponent implements OnInit, AfterViewInit {
     this.electronService.ipcRenderer.on('inputFolderChosen', (event, filePath, listOfFiles) => {
       this.wizard.totalNumberOfFiles = listOfFiles.length;
       this.wizard.listOfFiles = listOfFiles;
-      // TODO better prediction
 
       if (listOfFiles.length > 0) {
-        this.wizard.totalImportTime = Math.round(listOfFiles.length * 2.25 / 60);
+        // TODO better prediction
+        // this.wizard.totalImportTime = Math.round(listOfFiles.length * 2.25 / 60);
         this.wizard.selectedSourceFolder = filePath;
         this.wizard.selectedOutputFolder = filePath;
       }
@@ -1427,7 +1427,7 @@ export class HomeComponent implements OnInit, AfterViewInit {
     const height = parseInt(pxHeightForImport, 10);
     this.wizard.screenshotSizeForImport = height;
     // TODO better prediction
-    this.wizard.totalImportSize = Math.round((height / 100) * this.wizard.totalNumberOfFiles * 36 / 1000);
+    // this.wizard.totalImportSize = Math.round((height / 100) * this.wizard.totalNumberOfFiles * 36 / 1000);
   }
 
   /**

--- a/src/app/components/wizard.scss
+++ b/src/app/components/wizard.scss
@@ -2,8 +2,8 @@
 
 .wizard {
   background: $gray-10;
-  height: 100vh;
   height: calc(100vh - 50px);
+  overflow-x: hidden;
   overflow-y: scroll;
   padding-top: 30px;
   position: fixed;
@@ -283,4 +283,15 @@
       transform: translate(-48px, 24px);
     }
   }
+}
+
+.gradient-to-indicate-scrolling {
+  background-image: linear-gradient(rgba(230, 230, 230, 0), $gray-10);
+  bottom: 0;
+  display: block;
+  height: 100px;
+  pointer-events: none;
+  position: fixed;
+  width: 100vw;
+  z-index: 30;
 }

--- a/src/app/i18n/en.ts
+++ b/src/app/i18n/en.ts
@@ -259,7 +259,7 @@ export const English = {
     selectFolderWithVideo  :'Please select the folder with your video files',
     selectWhereFilesStored :'Please select the folder where your Video Hub will be stored',
     size                   :'size',
-    sizeOfScreenshots      :'Size of screenshots',
+    sizeOfScreenshots      :'Height of screenshots',
     sizeToImport           :'mb of disk space',
     timeToImport           :'minutes to import',
     videoDirectory         :'video directory',


### PR DESCRIPTION
🤷‍♂ 

Prediction of time required to extract thumbnails and final _vha-folder_ size was outdated ... 

While it's nice and kind to manage expectations, there's a high likelihood that the estimate will be wrong. If it's an underestimate, users might think the app is slow. If it's an overestimate, they might think the app is slow. 

Now that users can re-scan (resume importing), there should be less importance in stating a correct import time at start 😅 

ps - this PR also improves the _wizard_ with a nice gradient that indicates you should scroll 🤔 