### PR TITLE
Handle corrupt & unfinished download videos

### DIFF
--- a/main-archive.ts
+++ b/main-archive.ts
@@ -1,0 +1,96 @@
+// ========================================================================================
+//         Disabled method -- came from `main-extract.ts`
+// ========================================================================================
+
+/**
+ * Check whether screenshots can be extracted from video file
+ * To prevent erroring when file is corrupt
+ *
+ * Method currently disabled because it takes too long:
+ * For 15 screenshots, it takes 1 - 6 seconds to check if the file is not corrupt
+ * This is too long to wait during a regular extraction process
+ * since 99% of the files will not be corrupt
+ *
+ * Furthermore, it does not seem to catch all corrupt files anyway
+ *
+ * The current solution is simply to kill every ffmpeg process after some time
+ * in case it is stuck trying to parse an unparsable file
+ *
+ * Used to be after step 1 (checking video file still present)
+ *
+        //   return checkAllScreensExist(pathToVideo, duration, numOfScreens);
+        // })
+
+        // .then(content => {
+        //   console.log('1.5 - all screenshots present = ' + content);
+
+        //   if (content === false) {
+        //     throw new Error('FILE MIGHT BE CORRUPT');
+        //   }
+ *
+ * @param pathToVideo
+ * @param duration
+ * @param numberOfScreenshots
+ */
+const checkAllScreensExist__DISABLED = (
+  pathToVideo: string,
+  duration: number,
+  numberOfScreenshots: number,
+) => {
+
+  return new Promise((resolve, reject) => {
+
+    const t0: number = performance.now();
+
+    const totalCount = numberOfScreenshots;
+    const step: number = duration / (totalCount + 1);
+
+    // check for complete file
+    const check = (current: number): void => {
+      if (current === totalCount) {
+        console.log('resolving TRUE');
+
+        const t1: number = performance.now();
+        console.log('SS check: ' + (t1 - t0).toString());
+
+        return resolve(true);
+      }
+
+      const time = (current + 1) * step; // +1 so we don't pick the 0th frame
+      const corruptRegex = /Output file is empty, nothing was encoded/g;
+
+      const args = [
+        '-v', 'warning', '-ss', time, '-t', '1', '-i', pathToVideo, '-map', 'V', '-f', 'null', '-',
+      ];
+      // console.log('extracting clip frame 1');
+      const ffmpeg_process = spawn(ffmpegPath, args);
+      // Note from past Cal to future Cal:
+      // ALWAYS READ THE DATA, EVEN IF YOU DO NOTHING WITH IT
+      ffmpeg_process.stdout.on('data', data => {
+        if (globals.debug) {
+          console.log(data);
+          if (data.match(corruptRegex)) {
+            // skip this file
+            console.log(pathToVideo + ' was corrupt, skipping!');
+            return resolve(false);
+          }
+        }
+      });
+      ffmpeg_process.stderr.on('data', data => {
+        if (globals.debug) {
+          console.log('grep stderr: ' + data);
+          if (data.match(corruptRegex)) {
+            console.log(pathToVideo + ' was corrupt, skipping!');
+            return resolve(false);
+          }
+          return resolve(false);
+        }
+      });
+      ffmpeg_process.on('exit', () => {
+        check(current + 1);
+      });
+    };
+    check(0);
+  });
+
+};

--- a/main-extract.ts
+++ b/main-extract.ts
@@ -197,41 +197,42 @@ const extractFirstFrameArgs = (
  * that can get toggled while scanning all screenshots
  *
  * Extract following this order. Each stage returns a boolean
- * RESTART means go back to (1) with the next item on the list
+ * (^) means RESTART -- go back to (1) with the next item-to-extract on the list
  *
- *    1. check if input file exists
- *         true:                   go to (2)
- *         false:                    RESTART
- * THUMB ===================================
- *    2. check thumb exists
- *         true:                   go to (4)
- *         false:                  go to (3)
- *    3. extract the SINGLE screenshot
- *         true:   move to (4)
- *         false:  assume corrupt -- RESTART
- * FILMSTRIP ===============================
- *    4. check filmstrip exists
- *         true:                   go to (6)
- *         false:                  go to (5)
- *    5. extract the FILMSTRIP
- *         true:   clipSnippets === 0 ?
- *           true:   nothing to do - RESTART
- *           false:                go to (6)
- *         false:  assume corrupt -- RESTART
- * CLIP ====================================
- *    6. check clip exists
- *         true:                   go to (8)
- *         false:                  go to (7)
- *    7. extract the CLIP
- *         true:                   go to (8)
- *         false:  assume corrupt -- RESTART
- * CLIP THUMB ==============================
- *    8. check clip thumb exists
- *         true:   RESTART
- *         false:                  go to (9)
- *    9. extract the CLIP preview
- *         true:   RESTART
- *         false:  RESTART
+ * SOURCE FILE ============================
+ *   (1) check if input file exists
+ *         T:                           (2)
+ *         F:                           (^) restart
+ * THUMB ==================================
+ *   (2) check thumb exists
+ *         T:                           (4)
+ *         F:                           (3)
+ *   (3) extract the SINGLE screenshot
+ *         T:                           (4)
+ *         F:                           (^) restart - assume corrupt
+ * FILMSTRIP ==============================
+ *   (4) check filmstrip exists
+ *         T:                           (6)
+ *         F:                           (5)
+ *   (5) extract the FILMSTRIP
+ *         T: (clipSnippets === 0) ?
+ *             T:   nothing to do       (^) restart
+ *             F:                       (6)
+ *         F:                           (^) restart - assume corrupt
+ * CLIP ===================================
+ *   (6) check clip exists
+ *         T:                           (8)
+ *         F:                           (7)
+ *   (7) extract the CLIP
+ *         T:                           (8)
+ *         F:                           (^) restart - assume corrupt
+ * CLIP THUMB =============================
+ *   (8) check clip thumb exists
+ *         T:                           (^) restart
+ *         F:                           (9)
+ *   (9) extract the CLIP preview
+ *         T:                           (^) restart
+ *         F:                           (^) restart
  *
  * @param theFinalArray      -- finalArray of ImageElements
  * @param videoFolderPath    -- path to base folder where videos are
@@ -276,7 +277,7 @@ export function extractFromTheseFiles(
 
       const thumbnailSavePath: string = screenshotFolder + '/thumbnails/' + fileHash + '.jpg';
       const filmstripSavePath: string = screenshotFolder + '/filmstrips/' + fileHash + '.jpg';
-      const clipSavePath: string =      screenshotFolder + '/clips/' +      fileHash + '.mp4';
+      const clipSavePath:      string = screenshotFolder + '/clips/' +      fileHash + '.mp4';
       const clipThumbSavePath: string = screenshotFolder + '/clips/' +      fileHash + '.jpg';
 
       checkFileExists(pathToVideo)                                                            // (1)

--- a/main-extract.ts
+++ b/main-extract.ts
@@ -198,34 +198,37 @@ const extractFirstFrameArgs = (
  *
  * Extract following this order. Each stage returns a boolean
  * RESTART means go back to (1) with the next item on the list
+ *
  *    1. check if input file exists
- *         true:   go to (2)
- *         false:  RESTART
- *    ===== THUMB ====
+ *         true:                   go to (2)
+ *         false:                    RESTART
+ * THUMB ===================================
  *    2. check thumb exists
- *         true:   go to (4)
- *         false:  go to (3)
+ *         true:                   go to (4)
+ *         false:                  go to (3)
  *    3. extract the SINGLE screenshot
  *         true:   move to (4)
  *         false:  assume corrupt -- RESTART
- *    ===== FILMSTRIP =====
+ * FILMSTRIP ===============================
  *    4. check filmstrip exists
- *         true:   move to (6)
- *         false:  move to (5)
+ *         true:                   go to (6)
+ *         false:                  go to (5)
  *    5. extract the FILMSTRIP
- *         true:   if `clipSnippets` !== 0, move to (6) else RESTART
- *         false:  assume corrupt -- RSTART
- *    ===== CLIP =====
- *    6. check clip exists
- *         true:   move to (8)
- *         false:  mavo to (7)
- *    7. extract the CLIP
- *         true:   move to (8)
+ *         true:   clipSnippets === 0 ?
+ *           true:   nothing to do - RESTART
+ *           false:                go to (6)
  *         false:  assume corrupt -- RESTART
- *    ===== CLIP THUMB =====
+ * CLIP ====================================
+ *    6. check clip exists
+ *         true:                   go to (8)
+ *         false:                  go to (7)
+ *    7. extract the CLIP
+ *         true:                   go to (8)
+ *         false:  assume corrupt -- RESTART
+ * CLIP THUMB ==============================
  *    8. check clip thumb exists
  *         true:   RESTART
- *         false:  move to (9)
+ *         false:                  go to (9)
  *    9. extract the CLIP preview
  *         true:   RESTART
  *         false:  RESTART

--- a/main-extract.ts
+++ b/main-extract.ts
@@ -279,7 +279,7 @@ export function extractFromTheseFiles(
       checkFileExists(pathToVideo)                                                            // (1)
 
         .then((videoFileExists: boolean) => {
-          console.log('01 - video file extists = ' + videoFileExists);
+          console.log('01 - video file live = ' + videoFileExists);
 
           if (!videoFileExists) {
             throw new Error('VIDEO FILE NOT PRESENT');
@@ -289,7 +289,7 @@ export function extractFromTheseFiles(
         })
 
         .then((thumbExists: boolean) => {
-          console.log('02 - thumbnail exists = ' + thumbExists);
+          console.log('02 - thumbnail already present = ' + thumbExists);
 
           if (thumbExists) {
             return true;
@@ -305,7 +305,7 @@ export function extractFromTheseFiles(
         })
 
         .then((thumbSuccess: boolean) => {
-          console.log('02 - single screenshot now present = ' + thumbSuccess);
+          console.log('03 - single screenshot now present = ' + thumbSuccess);
 
           if (!thumbSuccess) {
             throw new Error('SINGLE SCREENSHOT EXTRACTION TIMED OUT - LIKELY CORRUPT');
@@ -315,7 +315,7 @@ export function extractFromTheseFiles(
         })
 
         .then((filmstripExists: boolean) => {
-          console.log('03 - filmstrip exists = ' + filmstripExists);
+          console.log('04 - filmstrip already present = ' + filmstripExists);
 
           if (filmstripExists) {
             return true;
@@ -331,7 +331,7 @@ export function extractFromTheseFiles(
         })
 
         .then((filmstripSuccess: boolean) => {
-          console.log('03 - filmstrip now present = ' + filmstripSuccess);
+          console.log('05 - filmstrip now present = ' + filmstripSuccess);
 
           if (!filmstripSuccess) {
             throw new Error('FILMSTRIP GENERATION TIMED OUT - LIKELY CORRUPT');
@@ -343,7 +343,7 @@ export function extractFromTheseFiles(
         })
 
         .then((clipExists: boolean) => {
-          console.log('04 - preview clip exists = ' + clipExists);
+          console.log('04 - preview clip already present = ' + clipExists);
 
           if (clipExists) {
             return true;
@@ -360,7 +360,7 @@ export function extractFromTheseFiles(
         })
 
         .then((clipGenerationSuccess: boolean) => {
-          console.log('04 - preview clip generated = ' + clipGenerationSuccess);
+          console.log('07 - preview clip now present = ' + clipGenerationSuccess);
 
           if (clipGenerationSuccess) {
             return checkFileExists(clipThumbSavePath);                                        // (8)
@@ -370,7 +370,7 @@ export function extractFromTheseFiles(
         })
 
         .then((clipThumbExists: boolean) => {
-          console.log('05 - preview clip exists = ' + clipThumbExists);
+          console.log('05 - preview clip thumb already present = ' + clipThumbExists);
 
           if (clipThumbExists) {
             return true;
@@ -383,13 +383,17 @@ export function extractFromTheseFiles(
         })
 
         .then((success: boolean) => {
-          console.log('05 - extracted preview clip thumbnail = ' + success);
+          console.log('09 - preview clip thumb now exists = ' + success);
+
+          if (success) {
+            console.log('======= ALL STEPS SUCCESSFUL ==========');
+          }
 
           extractIterator(); // resume iterating
         })
 
         .catch((err) => {
-          console.log('EXTRACTION ERROR: ' + err);
+          console.log('===> ERROR - RESTARTING: ' + err);
           extractIterator(); // resume iterating
         });
 

--- a/main-extract.ts
+++ b/main-extract.ts
@@ -447,8 +447,8 @@ function setExtractionDurations(
   const clipHeightFactor  = clipHeight / 144;
 
   return {                                                            // for me:
-    thumb:    500 * thumbHeightFactor,                                // never above 300ms
-    filmstrip: 600 * numOfScreens * thumbHeightFactor,                // rarely above 15s
+    thumb:     500 * thumbHeightFactor,                               // never above 300ms
+    filmstrip: 650 * numOfScreens * thumbHeightFactor,                // rarely above 15s, but 4K 30screens took 50s
     clip:     1000 * clipSnippets * snippetLength * clipHeightFactor, // barely ever above 15s
     clipThumb: 300 * clipHeightFactor,                                // never above 100ms
   };

--- a/main-extract.ts
+++ b/main-extract.ts
@@ -448,7 +448,7 @@ function setExtractionDurations(
 
   return {                                                            // for me:
     thumb:     500 * thumbHeightFactor,                               // never above 300ms
-    filmstrip: 650 * numOfScreens * thumbHeightFactor,                // rarely above 15s, but 4K 30screens took 50s
+    filmstrip: 700 * numOfScreens * thumbHeightFactor,                // rarely above 15s, but 4K 30screens took 50s
     clip:     1000 * clipSnippets * snippetLength * clipHeightFactor, // barely ever above 15s
     clipThumb: 300 * clipHeightFactor,                                // never above 100ms
   };

--- a/main-extract.ts
+++ b/main-extract.ts
@@ -430,39 +430,28 @@ function checkFileExists(pathToFile: string): Promise<boolean> {
  * Replace original file with new file
  * use ffmpeg to convert and letterbox to fit width and height
  *
- * @param oldFile
- * @param newFile
+ * @param oldFile full path to thumbnail to replace
+ * @param newFile full path to sounce image to use as replacement
  * @param height
  */
 export function replaceThumbnailWithNewImage(
   oldFile: string,
   newFile: string,
   height: number
-) {
+): Promise<boolean> {
 
-  return new Promise((resolve, reject) => {
+  console.log('Resizing new image and replacing old thumbnail');
 
-    console.log('Resizing new image and replacing old thumbnail');
+  const width: number = Math.floor(height * (16 / 9));
 
-    const width: number = Math.floor(height * (16 / 9));
+  const args = [
+    '-y', '-i', newFile,
+    '-vf', scaleAndPadString(width, height),
+    oldFile,
+  ];
 
-    const args = [
-      '-y', '-i', newFile,
-      '-vf', scaleAndPadString(width, height),
-      oldFile,
-    ];
-
-    // TODO - confirm 1s is enough
-    spawn_ffmpeg_and_run(args, 1000, 'replacing thumbnail')
-    .then(success => {
-      return resolve(success);
-    })
-    .catch(err => {
-      console.log('what error?');
-    });
-
-  });
-
+  return spawn_ffmpeg_and_run(args, 1000, 'replacing thumbnail');
+  // resizing an image file with ffmpeg should take less than 1 second
 }
 
 /**

--- a/main-extract.ts
+++ b/main-extract.ts
@@ -22,7 +22,7 @@
 // console.log('console.log disabled in main-extract.ts');
 // console.log = function() {};
 
-const { performance } = require('perf_hooks');  // for logging time taken during debug
+// const { performance } = require('perf_hooks');  // for logging time taken during debug
 
 const fs = require('fs');
 import * as path from 'path';
@@ -396,7 +396,7 @@ export function extractFromTheseFiles(
         })
 
         .catch((err) => {
-          console.log('===> ERROR - RESTARTING: ' + err);
+          // console.log('===> ERROR - RESTARTING: ' + err);
           extractIterator(); // resume iterating
         });
 
@@ -525,18 +525,17 @@ function spawn_ffmpeg_and_run(
 
   return new Promise((resolve, reject) => {
 
-    const t0: number = performance.now();
+    // const t0: number = performance.now();
 
     const ffmpeg_process = spawn(ffmpegPath, args);
 
     const killProcessTimeout = setTimeout(() => {
       if (!ffmpeg_process.killed) {
         ffmpeg_process.kill();
-        console.log(description + ' KILLED EARLY');
+        // console.log(description + ' KILLED EARLY');
         return resolve(false);
       }
     }, maxRunningTime);
-
 
     // Note from past Cal to future Cal:
     // ALWAYS READ THE DATA, EVEN IF YOU DO NOTHING WITH IT
@@ -552,110 +551,11 @@ function spawn_ffmpeg_and_run(
     });
     ffmpeg_process.on('exit', () => {
       clearTimeout(killProcessTimeout);
-      const t1: number = performance.now();
-      console.log(description + ': ' + (t1 - t0).toString());
+      // const t1: number = performance.now();
+      // console.log(description + ': ' + (t1 - t0).toString());
       return resolve(true);
     });
 
   });
 
 }
-
-
-
-// ========================================================================================
-//         Disabled method
-// ========================================================================================
-
-/**
- * Check whether screenshots can be extracted from video file
- * To prevent erroring when file is corrupt
- *
- * Method currently disabled because it takes too long:
- * For 15 screenshots, it takes 1 - 6 seconds to check if the file is not corrupt
- * This is too long to wait during a regular extraction process
- * since 99% of the files will not be corrupt
- *
- * Furthermore, it does not seem to catch all corrupt files anyway
- *
- * The current solution is simply to kill every ffmpeg process after some time
- * in case it is stuck trying to parse an unparsable file
- *
- * Used to be after step 1 (checking video file still present)
- *
-        //   return checkAllScreensExist(pathToVideo, duration, numOfScreens);
-        // })
-
-        // .then(content => {
-        //   console.log('1.5 - all screenshots present = ' + content);
-
-        //   if (content === false) {
-        //     throw new Error('FILE MIGHT BE CORRUPT');
-        //   }
- *
- * @param pathToVideo
- * @param duration
- * @param numberOfScreenshots
- */
-const checkAllScreensExist__DISABLED = (
-  pathToVideo: string,
-  duration: number,
-  numberOfScreenshots: number,
-) => {
-
-  return new Promise((resolve, reject) => {
-
-    const t0: number = performance.now();
-
-    const totalCount = numberOfScreenshots;
-    const step: number = duration / (totalCount + 1);
-
-    // check for complete file
-    const check = (current: number): void => {
-      if (current === totalCount) {
-        console.log('resolving TRUE');
-
-        const t1: number = performance.now();
-        console.log('SS check: ' + (t1 - t0).toString());
-
-        return resolve(true);
-      }
-
-      const time = (current + 1) * step; // +1 so we don't pick the 0th frame
-      const corruptRegex = /Output file is empty, nothing was encoded/g;
-
-      const args = [
-        '-v', 'warning', '-ss', time, '-t', '1', '-i', pathToVideo, '-map', 'V', '-f', 'null', '-',
-      ];
-      // console.log('extracting clip frame 1');
-      const ffmpeg_process = spawn(ffmpegPath, args);
-      // Note from past Cal to future Cal:
-      // ALWAYS READ THE DATA, EVEN IF YOU DO NOTHING WITH IT
-      ffmpeg_process.stdout.on('data', data => {
-        if (globals.debug) {
-          console.log(data);
-          if (data.match(corruptRegex)) {
-            // skip this file
-            console.log(pathToVideo + ' was corrupt, skipping!');
-            return resolve(false);
-          }
-        }
-      });
-      ffmpeg_process.stderr.on('data', data => {
-        if (globals.debug) {
-          console.log('grep stderr: ' + data);
-          if (data.match(corruptRegex)) {
-            console.log(pathToVideo + ' was corrupt, skipping!');
-            return resolve(false);
-          }
-          return resolve(false);
-        }
-      });
-      ffmpeg_process.on('exit', () => {
-        check(current + 1);
-      });
-    };
-    check(0);
-  });
-
-};

--- a/main-extract.ts
+++ b/main-extract.ts
@@ -19,6 +19,9 @@
 //          Imports
 // ========================================================================================
 
+// cool method to disable all console.log statements!
+// console.log = function() {};
+
 const { performance } = require('perf_hooks');
 
 const fs = require('fs');
@@ -93,12 +96,12 @@ const extractSingleFrame = (
     const ffmpeg_process = spawn(ffmpegPath, args);
     // Note from past Cal to future Cal:
     // ALWAYS READ THE DATA, EVEN IF YOU DO NOTHING WITH IT
-    ffmpeg_process.stdout.on('data', function (data) {
+    ffmpeg_process.stdout.on('data', data => {
       if (globals.debug) {
         console.log(data);
       }
     });
-    ffmpeg_process.stderr.on('data', function (data) {
+    ffmpeg_process.stderr.on('data', data => {
       if (globals.debug) {
         console.log('grep stderr: ' + data);
       }
@@ -112,7 +115,6 @@ const extractSingleFrame = (
   });
 
 };
-
 
 /**
  * Take N screenshots of a particular file
@@ -172,7 +174,7 @@ const generateScreenshotStrip = (
 
     const ffmpeg_process = spawn(ffmpegPath, args);
 
-    setTimeout(() => {
+    const myTimeout = setTimeout(() => {
       console.log('needs killing?');
       // console.log(ffmpeg_process);
       if (!ffmpeg_process.killed) {
@@ -183,12 +185,12 @@ const generateScreenshotStrip = (
 
     // Note from past Cal to future Cal:
     // ALWAYS READ THE DATA, EVEN IF YOU DO NOTHING WITH IT
-    ffmpeg_process.stdout.on('data', function (data) {
+    ffmpeg_process.stdout.on('data', data => {
       if (globals.debug) {
         console.log(data);
       }
     });
-    ffmpeg_process.stderr.on('data', function (data) {
+    ffmpeg_process.stderr.on('data', data => {
       if (globals.debug) {
         console.log('grep stderr: ' + data);
       }
@@ -196,6 +198,7 @@ const generateScreenshotStrip = (
     ffmpeg_process.on('exit', () => {
       const t1: number = performance.now();
       console.log('filmstrip: ' + (t1 - t0).toString());
+      clearTimeout(myTimeout);
       return resolve(true);
     });
 
@@ -261,12 +264,12 @@ const generatePreviewClip = (
     const ffmpeg_process = spawn(ffmpegPath, args);
     // Note from past Cal to future Cal:
     // ALWAYS READ THE DATA, EVEN IF YOU DO NOTHING WITH IT
-    ffmpeg_process.stdout.on('data', function (data) {
+    ffmpeg_process.stdout.on('data', data => {
       if (globals.debug) {
         console.log(data);
       }
     });
-    ffmpeg_process.stderr.on('data', function (data) {
+    ffmpeg_process.stderr.on('data', data => {
       if (globals.debug) {
         console.log('grep stderr: ' + data);
       }
@@ -304,12 +307,12 @@ const extractFirstFrame = (saveLocation: string, fileHash: string) => {
     const ffmpeg_process = spawn(ffmpegPath, args);
     // Note from past Cal to future Cal:
     // ALWAYS READ THE DATA, EVEN IF YOU DO NOTHING WITH IT
-    ffmpeg_process.stdout.on('data', function (data) {
+    ffmpeg_process.stdout.on('data', data => {
       if (globals.debug) {
         console.log(data);
       }
     });
-    ffmpeg_process.stderr.on('data', function (data) {
+    ffmpeg_process.stderr.on('data', data => {
       if (globals.debug) {
         console.log('grep stderr: ' + data);
       }
@@ -389,16 +392,6 @@ export function extractFromTheseFiles(
           if (content === false) {
             throw new Error('NOTPRESENT');
           }
-
-        //   return checkAllScreensExist(pathToVideo, duration, numOfScreens);
-        // })
-
-        // .then(content => {
-        //   console.log('DISABLED - all screenshots present = ' + content);
-
-        //   if (content === false) {
-        //     throw new Error('FILE MIGHT BE CORRUPT');
-        //   }
 
           return extractSingleFrame(
             pathToVideo, screenshotFolder, fileHash, screenshotHeight, duration
@@ -482,12 +475,12 @@ export function replaceThumbnailWithNewImage(
 
     const ffmpeg_process = spawn(ffmpegPath, args);
     // ALWAYS READ THE DATA, EVEN IF YOU DO NOTHING WITH IT
-    ffmpeg_process.stdout.on('data', function (data) {
+    ffmpeg_process.stdout.on('data', data => {
       if (globals.debug) {
         console.log(data);
       }
     });
-    ffmpeg_process.stderr.on('data', function (data) {
+    ffmpeg_process.stderr.on('data', data => {
       if (globals.debug) {
         console.log('grep stderr: ' + data);
       }
@@ -534,6 +527,18 @@ function scaleAndPadString(width: number, height: number): string {
  * The current solution is simply to kill every ffmpeg process after some time
  * in case it is stuck trying to parse an unparsable file
  *
+ * Used to be after step 1 (checking video file still present)
+ *
+        //   return checkAllScreensExist(pathToVideo, duration, numOfScreens);
+        // })
+
+        // .then(content => {
+        //   console.log('1.5 - all screenshots present = ' + content);
+
+        //   if (content === false) {
+        //     throw new Error('FILE MIGHT BE CORRUPT');
+        //   }
+ *
  * @param pathToVideo
  * @param duration
  * @param numberOfScreenshots
@@ -572,7 +577,7 @@ const checkAllScreensExist__DISABLED = (
       const ffmpeg_process = spawn(ffmpegPath, args);
       // Note from past Cal to future Cal:
       // ALWAYS READ THE DATA, EVEN IF YOU DO NOTHING WITH IT
-      ffmpeg_process.stdout.on('data', function (data) {
+      ffmpeg_process.stdout.on('data', data => {
         if (globals.debug) {
           console.log(data);
           if (data.match(corruptRegex)) {
@@ -582,7 +587,7 @@ const checkAllScreensExist__DISABLED = (
           }
         }
       });
-      ffmpeg_process.stderr.on('data', function (data) {
+      ffmpeg_process.stderr.on('data', data => {
         if (globals.debug) {
           console.log('grep stderr: ' + data);
           if (data.match(corruptRegex)) {

--- a/main-extract.ts
+++ b/main-extract.ts
@@ -76,16 +76,18 @@ const checkAllScreensExist = (
     const step: number = duration / (totalCount + 1);
 
     // check for complete file
-    const check = (current) => {
+    const check = (current: number): void => {
       if (current === totalCount) {
+        console.log('resolving TRUE');
         resolve(true);
+        return; // else the rest of the function runs === bad!
       }
 
       // !!!!!!
       // TODO -- see if still a problem !!!!!!!!!!!!!
       // Notice this keeps running even after screenshots successfully extracted!
       // !!!!!!
-      console.log('checking ' + current);
+      // console.log('checking ' + current);
 
       const time = (current + 1) * step; // +1 so we don't pick the 0th frame
       const corruptRegex = /Output file is empty, nothing was encoded/g;
@@ -118,13 +120,14 @@ const checkAllScreensExist = (
         }
       });
       ffmpeg_process.on('exit', () => {
+        console.log('advancing');
         check(current + 1);
       });
     };
-    console.log('checkAllScreensExist is DISABLED !!!');
+    // console.log('checkAllScreensExist is DISABLED !!!');
     // uncomment line below to enable
-    // check(0);
-    resolve(true);
+    check(0);
+    // resolve(true);
   });
 
 };
@@ -236,6 +239,16 @@ const generateScreenshotStrip = (
     );
 
     const ffmpeg_process = spawn(ffmpegPath, args);
+
+    setTimeout(() => {
+      console.log('needs killing?');
+      // console.log(ffmpeg_process);
+      if (!ffmpeg_process.killed) {
+        ffmpeg_process.kill();
+        console.log('process KILLED!');
+      }
+    }, 3000);
+
     // Note from past Cal to future Cal:
     // ALWAYS READ THE DATA, EVEN IF YOU DO NOTHING WITH IT
     ffmpeg_process.stdout.on('data', function (data) {
@@ -492,7 +505,7 @@ export function extractFromTheseFiles(
 
         .catch((err) => {
           console.log('EXTRACTION ERROR: ' + err);
-          extractIterator();
+          extractIterator(); // resume iterating
         });
 
     } else {

--- a/main-extract.ts
+++ b/main-extract.ts
@@ -157,35 +157,13 @@ const generateScreenshotStrip = (
       saveLocation + '/filmstrips/' + fileHash + '.jpg'
     );
 
-    const t0: number = performance.now();
-
-    const ffmpeg_process = spawn(ffmpegPath, args);
-
-    const killProcessTimeout = setTimeout(() => {
-      if (!ffmpeg_process.killed) {
-        ffmpeg_process.kill();
-        console.log('Filmstrip process KILLED!');
-        return resolve(false);
-      }
-    }, 3000);
-
-    // Note from past Cal to future Cal:
-    // ALWAYS READ THE DATA, EVEN IF YOU DO NOTHING WITH IT
-    ffmpeg_process.stdout.on('data', data => {
-      if (globals.debug) {
-        console.log(data);
-      }
-    });
-    ffmpeg_process.stderr.on('data', data => {
-      if (globals.debug) {
-        console.log('grep stderr: ' + data);
-      }
-    });
-    ffmpeg_process.on('exit', () => {
-      const t1: number = performance.now();
-      console.log('filmstrip: ' + (t1 - t0).toString());
-      clearTimeout(killProcessTimeout);
-      return resolve(true);
+    // TODO -- make 3000 a function of # of screenshots
+    spawn_ffmpeg_and_run(args, 3000, 'filmstrip')
+    .then(success => {
+      return resolve(success);
+    })
+    .catch(err => {
+      console.log('what error?');
     });
 
   });
@@ -246,22 +224,13 @@ const generatePreviewClip = (
               saveLocation + '/clips/' + fileHash + '.mp4');
     // phfff glad that's over
 
-    // now make it all worth it!
-    const ffmpeg_process = spawn(ffmpegPath, args);
-    // Note from past Cal to future Cal:
-    // ALWAYS READ THE DATA, EVEN IF YOU DO NOTHING WITH IT
-    ffmpeg_process.stdout.on('data', data => {
-      if (globals.debug) {
-        console.log(data);
-      }
-    });
-    ffmpeg_process.stderr.on('data', data => {
-      if (globals.debug) {
-        console.log('grep stderr: ' + data);
-      }
-    });
-    ffmpeg_process.on('exit', () => {
-      return resolve(true);
+    // TODO - determine max length
+    spawn_ffmpeg_and_run(args, 3000, 'clip')
+    .then(success => {
+      return resolve(success);
+    })
+    .catch(err => {
+      console.log('what error?');
     });
 
   });
@@ -292,22 +261,14 @@ const extractFirstFrame = (
       '-f', 'image2',
       saveLocation + '/clips/' + fileHash + '.jpg',
     ];
-    // console.log('extracting clip frame 1');
-    const ffmpeg_process = spawn(ffmpegPath, args);
-    // Note from past Cal to future Cal:
-    // ALWAYS READ THE DATA, EVEN IF YOU DO NOTHING WITH IT
-    ffmpeg_process.stdout.on('data', data => {
-      if (globals.debug) {
-        console.log(data);
-      }
-    });
-    ffmpeg_process.stderr.on('data', data => {
-      if (globals.debug) {
-        console.log('grep stderr: ' + data);
-      }
-    });
-    ffmpeg_process.on('exit', () => {
-      return resolve(true);
+
+    // TODO - confirm 300 ms is enough
+    spawn_ffmpeg_and_run(args, 300, 'clip first frame')
+    .then(success => {
+      return resolve(success);
+    })
+    .catch(err => {
+      console.log('what error?');
     });
 
   });
@@ -470,21 +431,13 @@ export function replaceThumbnailWithNewImage(
       oldFile,
     ];
 
-    const ffmpeg_process = spawn(ffmpegPath, args);
-    // ALWAYS READ THE DATA, EVEN IF YOU DO NOTHING WITH IT
-    ffmpeg_process.stdout.on('data', data => {
-      if (globals.debug) {
-        console.log(data);
-      }
-    });
-    ffmpeg_process.stderr.on('data', data => {
-      if (globals.debug) {
-        console.log('grep stderr: ' + data);
-      }
-    });
-    ffmpeg_process.on('exit', () => {
-      console.log('Done replacing the thumbnail!');
-      return resolve(true);
+    // TODO - confirm 1s is enough
+    spawn_ffmpeg_and_run(args, 1000, 'replacing thumbnail')
+    .then(success => {
+      return resolve(success);
+    })
+    .catch(err => {
+      console.log('what error?');
     });
 
   });

--- a/main-globals.ts
+++ b/main-globals.ts
@@ -2,7 +2,7 @@ export const globals: Globals = {
   angularApp: null,            // reference used to send messages back to Angular App
   cancelCurrentImport: false,
   currentlyOpenVhaFile: '',    // OFFICAL DECREE IN NODE WHICH FILE IS CURRENTLY OPEN !!!
-  debug: true,
+  debug: false,
   hubName: 'untitled',         // in case user doesn't name their hub any name
   selectedOutputFolder: '',
   selectedSourceFolder: '',

--- a/main-globals.ts
+++ b/main-globals.ts
@@ -2,7 +2,7 @@ export const globals: Globals = {
   angularApp: null,            // reference used to send messages back to Angular App
   cancelCurrentImport: false,
   currentlyOpenVhaFile: '',    // OFFICAL DECREE IN NODE WHICH FILE IS CURRENTLY OPEN !!!
-  debug: false,
+  debug: true,
   hubName: 'untitled',         // in case user doesn't name their hub any name
   selectedOutputFolder: '',
   selectedSourceFolder: '',


### PR DESCRIPTION
Summary: adding a timeout and killing any `ffmpeg` process that takes too long 😅 

New workflow:
1. do not do any kind of checking for whether the video file is corrupt
    - previous script takes too long (2-6 seconds for 15 screenshots -- even if the video is not corrupt)
2. spend at most 1s** trying to generate _first thumbnail_, if it fails, move on to the next file*
    - it takes about 60-80ms on my computer to extract one screenshot; 1s should be enough 🤷‍♂ 
3. spend at most 5s** trying to generate _filmstrip_, if that fails, move on to the next file*
    - this time will be a function of number of screenshots to extract, not yet determined
4. spend at most 10s** trying to generate _clip_, if that fails, move on to the next file*
    - this time will be a function of number of screenshots to extract, not yet determined

\* basically assume everything is corrupt and skip file (do not try to extract anything else)
\** better defaults will be experimentally found before merging 😅 

⚠️ I'm disabling the script that is meant to detect errors in files doesn't seem to do that -- perhaps it worked previously but currently it doesn't for me 😓 

I'll be working on this -- version 2.0.0 can't get released without handling corrupt files 🙆‍♂ 

ps - _promises_ are tricky to format, I'm following this: https://github.com/airbnb/javascript/issues/216#issuecomment-88066358