### PR TITLE
should not interfere when installing next to version 1.X.X

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -1,5 +1,7 @@
 {
   "productName": "Video Hub App 2",
+  "appId": "com.videohubapp.videohubapp2",
+  "copyright": "Copyright © 2019 Boris Yakubchik",
   "directories": {
     "output": "release/"
   },

--- a/main.ts
+++ b/main.ts
@@ -432,7 +432,7 @@ ipc.on('select-default-video-player', function (event) {
   dialog.showOpenDialog(win, {
     title: systemMessages.selectDefaultPlayer,
     filters: [{
-      name: 'Executable',
+      name: 'Executable', // TODO: i18n fixme
       extensions: ['exe', 'app']
     }],
     properties: ['openFile']
@@ -674,7 +674,7 @@ ipc.on('system-open-file-through-modal', function (event, somethingElse) {
   dialog.showOpenDialog(win, {
       title: systemMessages.selectPreviousHub,
       filters: [{
-        name: 'Video Hub App 2 files',
+        name: 'Video Hub App 2 files', // TODO -- i18n FIX ME
         extensions: ['vha2']
       }],
       properties: ['openFile']

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "video-hub-app",
+  "name": "video-hub-app-2",
   "version": "2.0.0",
-  "description": "Video Hub App - browse, search, preview your videos",
+  "description": "Video Hub App 2 - browse, search, preview your videos",
   "homepage": "http://www.videohubapp.com",
   "author": {
     "name": "Boris Yakubchik",

--- a/src/app/components/home.component.ts
+++ b/src/app/components/home.component.ts
@@ -128,9 +128,9 @@ export class HomeComponent implements OnInit, AfterViewInit {
   // ***************************** BUILD TOGGLE *********************************************
   // ========================================================================================
   demo = false;
-  webDemo = false;
   macVersion = false;
   // !!! make sure to update the `globals.version` and the `package.json` version numbers !!!
+  // webDemo = false;
   // ========================================================================================
 
   versionNumber = globals.version;


### PR DESCRIPTION
Maybe it's only on my computer, but when installing video hub app 2.0.0 next to video hub app 1.3.0 it would corrupt version 1. And also after installing 2, installing 1.3.0 would install in the same folder `Video Hub App 2` 😖  ... 

Anyway, now I explicitly set the `appId` in _electron-builder.json_ and that should resolve the problem.

I tested on another computer 🤷‍♂ ... my computer still has some trouble 🤷‍♂ 