### PR TITLE
Fix folder browse bug

### DIFF
--- a/main-support.ts
+++ b/main-support.ts
@@ -260,8 +260,9 @@ export function getVideoPathsAndNames(sourceFolderPath: string): ImageElement[] 
           } else {
             const extension = file.name.split('.').pop();
             if (acceptableFiles.includes(extension.toLowerCase()) && !file.name.match(fileIgnoreRegex)) {
-              // before adding, remove the redundant prefix: sourceFolderPath, and convert forward slashes into back slashes
-              const partialPath = dir.replace(sourceFolderPath, '').replace(/\\/g, '/');
+              // before adding, remove the redundant prefix: sourceFolderPath, and convert back slashes into forward slashes
+              // turns out app works best when the partialPath starts with `/` even in cases when video in root folder
+              const partialPath = ('/' + dir.replace(sourceFolderPath, '').replace(/\\/g, '/')).replace('//', '/');
               // fil finalArray with 3 correct and 5 dummy pieces of data
               finalArray[elementIndex] = NewImageElement();
               finalArray[elementIndex].cleanName = cleanUpFileName(file.name);


### PR DESCRIPTION
Should close #270 😅 

Seems like `partialPath` should always have a leading `/` even if in root folder 👌 

Previously creating a _hub_ from the root of an external hard drive (or thumb drive) would work fine, but when you tried to navigate with the _Folder view_, you would not see any videos in folders (and the directories would be messed up).

Now everything should work fine 😅 

Works on _Windows_ and _Mac_ 👍 