### PR TITLE
[#324] Fix scrolling bug after switching from text view 

### DIFF
--- a/src/app/components/home.component.ts
+++ b/src/app/components/home.component.ts
@@ -1210,6 +1210,7 @@ export class HomeComponent implements OnInit, AfterViewInit {
       this.restoreViewSize(uniqueKey);
       this.appState.currentView = <SupportedView>uniqueKey;
       this.computeTextBufferAmount();
+      this.virtualScroller.invalidateAllCachedMeasurements();
       this.scrollToTop();
 
       // ======== Filter buttons =========================


### PR DESCRIPTION
Fixes #324 

```
This PR resets the virtual scroller whenever users toggle 
between views, which prevents the scrolling bug after user 
switches from text view.
```