### PR TITLE
[#332] Fix bug of tags that persists after switching hubs

### DIFF
--- a/src/app/components/home.component.ts
+++ b/src/app/components/home.component.ts
@@ -660,6 +660,7 @@ export class HomeComponent implements OnInit, AfterViewInit {
 
       this.folderViewNavigationPath = '';
 
+      this.manualTagsService.removeAllTags();
       this.setTags(finalObject.addTags, finalObject.removeTags);
       this.manualTagsService.populateManualTagsService(finalObject.images);
 

--- a/src/app/components/tags-manual/manual-tags.service.ts
+++ b/src/app/components/tags-manual/manual-tags.service.ts
@@ -37,6 +37,14 @@ export class ManualTagsService {
   }
 
   /**
+   * Removes all the existing tags in {@code tagList} and {@code tagsMap}
+   */
+  removeAllTags(): void {
+    this.tagsMap.clear();
+    this.tagsList = [];
+  }
+
+  /**
    * Get the most likely tag
    * TODO -- curently it gets the FIRST match; later get the MOST COMMON (confer with tagsMap)
    * @param text


### PR DESCRIPTION
Fixes #332 

```
When switching over one hub to another, the tags in the tag 
tray persists, as the tags of the previous hub are not cleared 
after switching over to the next hub.

This PR clears the tags whenever users switch between hubs,
which will prevent the previous tags to persist.
```