### PR TITLE
Bugfixes before 2.1.0

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -35,7 +35,8 @@
       "../node_modules/@ffprobe-installer"
     ],
     "target": [
-      "nsis"
+      "nsis",
+      "portable"
     ]
   },
   "mac": {

--- a/main-globals.ts
+++ b/main-globals.ts
@@ -8,7 +8,7 @@ export const globals: Globals = {
   hubName: 'untitled',         // in case user doesn't name their hub any name
   selectedOutputFolder: '',
   selectedSourceFolder: '',
-  version: '2.0.0',            // update it and the `package.json` version in tandem before release!
+  version: '2.1.0',            // update it and the `package.json` version in tandem before release!
   vhaFileVersion: 2,
   winRef: null,
   screenshotSettings: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "video-hub-app-2",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "video-hub-app-2",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Video Hub App 2 - browse, search, preview your videos",
   "homepage": "http://www.videohubapp.com",
   "author": {

--- a/src/app/components/home.component.html
+++ b/src/app/components/home.component.html
@@ -138,6 +138,7 @@
       <li
         *ngIf="settingsButtons['showDeleteOption'].toggled"
         (click)="deleteThisFile(currentRightClickedItem)"
+        [ngClass]="{ 'right-click-disabled': !rootFolderLive }"
         class="right-click-delete"
       >{{ 'RIGHTCLICK.delete' | translate }}</li>
     </ul>

--- a/src/app/components/home.component.ts
+++ b/src/app/components/home.component.ts
@@ -381,6 +381,12 @@ export class HomeComponent implements OnInit, AfterViewInit {
           this.initiateClose();
           break;
 
+        case ('w'):
+          event.preventDefault();
+          event.stopPropagation();
+          this.initiateClose();
+          break;
+
         case ('n'):
           this.startWizard();
           this.settingsModalOpen = false;

--- a/src/app/components/home.component.ts
+++ b/src/app/components/home.component.ts
@@ -1,5 +1,7 @@
 import { AfterViewInit, ChangeDetectorRef, Component, ElementRef, HostListener, OnInit, ViewChild } from '@angular/core';
 
+import * as path from 'path';
+
 import { TranslateService } from '@ngx-translate/core';
 import { VirtualScrollerComponent } from 'ngx-virtual-scroller';
 
@@ -938,7 +940,11 @@ export class HomeComponent implements OnInit, AfterViewInit {
 
     this.currentPlayingFolder = clickedElement.partialPath;
     this.currentPlayingFile = clickedElement.cleanName;
-    const fullPath = this.appState.selectedSourceFolder + clickedElement.partialPath + '/' + clickedElement.fileName;
+    const fullPath = path.join(
+      this.appState.selectedSourceFolder,
+      clickedElement.partialPath,
+      clickedElement.fileName
+    );
     this.fullPathToCurrentFile = fullPath;
 
     if (this.rootFolderLive && this.appState.preferredVideoPlayer) {
@@ -1078,8 +1084,10 @@ export class HomeComponent implements OnInit, AfterViewInit {
     this.scrollToTop();
   }
 
+  /**
+   * Open folder that contains the (current) clicked file
+   */
   openInExplorer(): void {
-    // console.log('should open explorer');
     this.electronService.ipcRenderer.send('openInExplorer', this.fullPathToCurrentFile);
   }
 
@@ -1797,10 +1805,11 @@ export class HomeComponent implements OnInit, AfterViewInit {
    * Code similar to `openVideo()`
    */
   openContainingFolderNow(): void {
-    this.fullPathToCurrentFile = this.appState.selectedSourceFolder +
-      this.currentRightClickedItem.partialPath +
-      '/' +
-      this.currentRightClickedItem.fileName;
+    this.fullPathToCurrentFile = path.join(
+      this.appState.selectedSourceFolder,
+      this.currentRightClickedItem.partialPath,
+      this.currentRightClickedItem.fileName
+    );
 
     this.openInExplorer();
   }

--- a/src/app/components/rightclick.scss
+++ b/src/app/components/rightclick.scss
@@ -40,13 +40,13 @@
     }
   }
 
+  .right-click-delete {
+    color: $dark-red;
+  }
+
   .right-click-disabled {
     color: $gray-50;
     pointer-events: none;
-  }
-
-  .right-click-delete {
-    color: $dark-red;
   }
 }
 

--- a/src/app/components/search.scss
+++ b/src/app/components/search.scss
@@ -61,6 +61,7 @@
   display: inline-block;
   font-size: 10px;
   padding: 2px 4px 3px;
+  word-break: break-word;
 }
 
 .search-word {

--- a/src/app/components/top/top.component.ts
+++ b/src/app/components/top/top.component.ts
@@ -15,6 +15,10 @@ export class TopComponent {
   @Input() set folderString(folderString: string) {
     this._folder = (folderString && folderString.trim()) || '';
     this.folderNameArray = this._folder.split('/');
+    this.folderNameArray = this.folderNameArray.filter((element, index) => {
+      // TODO -- fix this up:
+      return index === 0 || element !== ''; // ATROCIOUS hack! -- simply to prevent ["", ""]
+    });
   }
   get folderString(): string { return this._folder; }
 

--- a/src/app/components/views/filmstrip/filmstrip.component.ts
+++ b/src/app/components/views/filmstrip/filmstrip.component.ts
@@ -49,7 +49,7 @@ export class FilmstripComponent implements OnInit {
     if (this.hoverScrub) {
       const imgWidth = this.imgHeight * (16 / 9); // hardcoded aspect ratio
       const containerWidth = this.filmstripHolder.nativeElement.getBoundingClientRect().width;
-      const howManyScreensOutsideCutoff = (this.video.screens + 1) - Math.floor(containerWidth / imgWidth);
+      const howManyScreensOutsideCutoff = this.video.screens - Math.floor(containerWidth / imgWidth);
 
       const cursorX = $event.layerX; // cursor's X position inside the filmstrip element
       this.filmXoffset = imgWidth * Math.floor(cursorX / (containerWidth / howManyScreensOutsideCutoff));


### PR DESCRIPTION
Gearing up for `2.1.0` release

- Right click disabled when folder not connected
- `Ctrl` + `w` shortcut will first save the `vha2` file (users will not lose entered _tags_ 😅 )
- Include `portable` version of the app with the build
- Right-click -> "Open folder" now works 😅 
- Prevent `> >` in the folder path (top row of app) when looking at video in root of source folder
- Handle search/filter 'tag' (view) for long folder names with no spaces (e.g. right-click and "View folder") -- the way it appears in search/filter bar on the left (should no longer cut off the text)
- No more blank (black) screen at the end of every film strip 🎉 

Closes #339 
Closes #343 