### PR TITLE
Clean up duration / length pipe

### DIFF
--- a/main-support.ts
+++ b/main-support.ts
@@ -109,7 +109,7 @@ export function insertTemporaryFields(imagesArray: ImageElement[]): ImageElement
 }
 
 /**
- * Generate the file size formatted as XXXmb or X.Xgb
+ * Generate the file size formatted as ### MB or #.# GB
  * THIS CODE DUPLICATES THE CODE IN `file-size.pipe.ts`
  * @param fileSize
  */

--- a/main-support.ts
+++ b/main-support.ts
@@ -110,14 +110,15 @@ export function insertTemporaryFields(imagesArray: ImageElement[]): ImageElement
 
 /**
  * Generate the file size formatted as XXXmb or X.Xgb
+ * THIS CODE DUPLICATES THE CODE IN `file-size.pipe.ts`
  * @param fileSize
  */
 function getFileSizeDisplay(sizeInBytes: number): string {
   if (sizeInBytes) {
     const rounded = Math.round(sizeInBytes / 1000000);
     return (rounded > 999
-              ? Math.round(rounded / 100) / 10 + 'gb'
-              : rounded + 'mb');
+              ? (rounded / 1000).toFixed(1) + ' GB'
+              : rounded + ' MB');
   } else {
     return '';
   }

--- a/src/app/components/statistics/statistics.component.html
+++ b/src/app/components/statistics/statistics.component.html
@@ -81,22 +81,22 @@
 
       <tr>
         <td>{{ 'STATISTICS.shortest' | translate }}</td>
-        <td class="rightCol">{{ shortest | lengthPipe : true }}</td>
+        <td class="rightCol">{{ shortest | lengthPipe : 'folder' }}</td>
       </tr>
 
       <tr>
         <td>{{ 'STATISTICS.longest' | translate }}</td>
-        <td class="rightCol">{{ longest | lengthPipe : true : true }}</td>
+        <td class="rightCol">{{ longest | lengthPipe : 'folder' }}</td>
       </tr>
 
       <tr>
         <td>{{ 'STATISTICS.total' | translate : true }}</td>
-        <td class="rightCol">{{ totalLength | lengthPipe : true : true : true }}</td>
+        <td class="rightCol">{{ totalLength | lengthPipe : 'folder' }}</td>
       </tr>
 
       <tr>
         <td>{{ 'STATISTICS.average' | translate }}</td>
-        <td class="rightCol">{{ avgLength | lengthPipe : true }}</td>
+        <td class="rightCol">{{ avgLength | lengthPipe : 'folder' }}</td>
       </tr>
 
       <tr>

--- a/src/app/components/views/file/file.component.html
+++ b/src/app/components/views/file/file.component.html
@@ -26,7 +26,7 @@
         class="length"
         [ngClass]="{ 'meta-dark-mode': darkMode }"
       >
-        {{ video.duration | lengthPipe : true : true : true }}
+        {{ video.duration | lengthPipe : 'folder' }}
       </div>
 
     </ng-container>

--- a/src/app/components/views/thumbnail/preview.component.html
+++ b/src/app/components/views/thumbnail/preview.component.html
@@ -25,7 +25,7 @@
         }"
       ></div>
 
-      <span *ngIf="showMeta" class="time folder-time">{{ video.duration | lengthPipe : true : true : true }}</span>
+      <span *ngIf="showMeta" class="time folder-time">{{ video.duration | lengthPipe : 'folder' }}</span>
     </div>
 
     <div *ngIf="video.cleanName === '*FOLDER*' && video.fileName !== '*UP*'" class="folder-icon">

--- a/src/app/pipes/file-size.pipe.ts
+++ b/src/app/pipes/file-size.pipe.ts
@@ -6,14 +6,21 @@ import { Pipe, PipeTransform } from '@angular/core';
 export class FileSizePipe implements PipeTransform {
 
   /**
-   * Return size of file formatted as XXX{mb,gb}
+   * Return size of file formatted as XXX{MB,GB}
    * @param sizeInBytes -- file size in bytes
+   * @param excludeParen - whether (2.3GB) or 2.3GB
    */
-  transform(sizeInBytes: number, excludeParen: boolean): string {
+  transform(sizeInBytes: number, excludeParen?: boolean): string {
     if (sizeInBytes) {
       const rounded = Math.round(sizeInBytes / 1000000);
-      // tslint:disable-next-line:max-line-length
-      return (excludeParen ? '' : '(') + (rounded > 999 ? Math.round(rounded / 100) / 10 + 'gb' : rounded + 'mb') + (excludeParen ? '' : ')');
+
+      return (excludeParen ? '' : '(')
+           + (
+              rounded > 999
+                ? (rounded / 1000).toFixed(1) + ' GB'
+                : rounded                     + ' MB'
+              )
+           + (excludeParen ? '' : ')');
     } else {
       return '';
     }

--- a/src/app/pipes/file-size.pipe.ts
+++ b/src/app/pipes/file-size.pipe.ts
@@ -6,7 +6,7 @@ import { Pipe, PipeTransform } from '@angular/core';
 export class FileSizePipe implements PipeTransform {
 
   /**
-   * Return size of file formatted as XXX{MB,GB}
+   * Return size of file formatted as ### MB or ### GB
    * @param sizeInBytes -- file size in bytes
    * @param excludeParen - whether (2.3GB) or 2.3GB
    */

--- a/src/app/pipes/folder-view.pipe.ts
+++ b/src/app/pipes/folder-view.pipe.ts
@@ -189,7 +189,7 @@ export class FolderViewPipe implements PipeTransform {
           folderWithStuff.duration        = folderProperties.duration,
           folderWithStuff.fileName        = key.replace('/', ''),
           folderWithStuff.fileSize        = folderProperties.byteSize,
-          folderWithStuff.fileSizeDisplay = value.length.toString(),
+          folderWithStuff.fileSizeDisplay = value.length.toString(), // indicates the number of files in the folder!
           folderWithStuff.hash            = this.extractFourPreviewHashes(value),
           folderWithStuff.index           = -1, // always show at the top (but after the `UP` folder) in the default view
           folderWithStuff.mtime           = folderProperties.mtime,

--- a/src/app/pipes/length.pipe.ts
+++ b/src/app/pipes/length.pipe.ts
@@ -1,5 +1,7 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
+type TimeFormat = 'slider' | 'file' | 'folder';
+
 @Pipe({
   name: 'lengthPipe'
 })
@@ -9,46 +11,55 @@ export class LengthPipe implements PipeTransform {
    * Return length of video file formatted as X:XX:XX
    * or if `omitSeconds` then `Xhr XXmin`
    * @param numOfSec
-   * @param omitSeconds
-   * @param printHrMin -- include `hr` and `min` in display
-   * @param printDays  -- include `days` -- used only in `statistics.component.html`
+   * @param destination -- dictates the output format (TimeFormat)
    */
   transform(
     numOfSec: number,
-    omitSeconds?: boolean,
-    printHrMin?: boolean,
-    printDays?: boolean
+    destination: TimeFormat = 'file'
   ): string {
+
     if (numOfSec === undefined) {
+      // short circuit
       return '';
     } else if (numOfSec === Infinity) {
+      // happens on a slider
       return 'every';
-    } else {
-      const hh = (Math.floor(numOfSec / 3600)).toString();
-      const mm = (Math.floor(numOfSec / 60) % 60).toString();
-      const ss = (Math.floor(numOfSec) % 60).toString();
+    }
 
-      if (omitSeconds) {
-        const zeroHours = (hh === '0');
-        const display = (zeroHours ? '' : hh + ':')
-               + (mm.length !== 2 ? (zeroHours ? '' : '0') + mm : mm)
-               + (zeroHours ? ' min' : '');
-        if (printHrMin) {
-          if (printDays) {
-            const dd: number = (Math.floor(numOfSec / 86400));
-            if (dd > 3) {
-              return dd.toString() + '+ days';
-            }
-          }
-          return (display.replace(':', ' hr ') + ' min');
-        } else {
-          return display;
-        }
+    const d: number = Math.floor(numOfSec / 86400);
+    const h: string = (Math.floor(numOfSec / 3600)).toString();
+    const m: string = (Math.floor(numOfSec / 60) % 60).toString();
+    const s: string = (Math.floor(numOfSec) % 60).toString();
+
+    if (destination === 'slider') {
+      // slider should behave thus:
+      // 0 min ... 1 min ... 59 min, 1:00, 1:01 ... 4:20 ...
+      if (h !== '0') {
+        return h + ':' + m.padStart(2, '0');
       } else {
-        return (hh !== '0' ? hh + ':' : '')
-               + (mm.length !== 2 ? '0' + mm : mm)
-               + ':'
-               + (ss.length !== 2 ? '0' : '') + ss;
+        return m + ' min';
+      }
+    } else if (destination === 'file') {
+      // file should behave thus:
+      // 0:00, 0:01 ... 0:59, 1:00, 1:01 ... 59:59, 1:00:00 ... 3:14:15 ...
+      if (h !== '0') {
+        return h + ':' + m.padStart(2, '0') + ':' + s.padStart(2, '0');
+      } else {
+        return           m.padStart(2, '0') + ':' + s.padStart(2, '0');
+      }
+    } else if (destination === 'folder') {
+      // should behave thus:
+      // <1min, 1min ... 59 min, 1 hr 00 min, 1 hr 01 min ... 3 hr 47 min ... 23 hr 59 min, 24 hr ... 69 hr ... 3+ days ... 42+ days
+      if (d > 3) {
+        return d.toString() + '+ days';
+      } else if (parseInt(h, 10) > 24) {
+        return h + ' hr';
+      } else if (h !== '0') {
+        return h + ' hr ' + m.padStart(2, '0') + ' min';
+      } else if (m !== '0') {
+        return m + ' min';
+      } else {
+        return '<1 min';
       }
     }
   }

--- a/src/app/pipes/wrapper.pipe.ts
+++ b/src/app/pipes/wrapper.pipe.ts
@@ -7,7 +7,7 @@ import { LengthPipe } from './length.pipe';
 export class WrapperPipe implements PipeTransform {
   transform(value: any, pipe?: string): any {
     if (pipe === 'lengthPipe') {
-      return new LengthPipe().transform(value, true);
+      return new LengthPipe().transform(value, 'slider');
     }
     return value;
   }


### PR DESCRIPTION
Closes #375 

*File duration display*
- Fixes the `min min` duration when folder has less than 1 hour total of videos inside
- Clean up the `length.pipe` to use an easy-to understand styling convention
    - no more boolean argument 'soup', just pass in the `TimeFormat` 😅 

*File size display*
- File size always has a space before `GB` and `MB`
- File size now is capital letters `GB` not `gb` 🤷‍♂ 
- File size in GB always has 1 decimal precision (e.g. 1.0 GB not 1 GB)