### PR TITLE
Auto generated tag better matching

### DIFF
--- a/main-support.ts
+++ b/main-support.ts
@@ -242,9 +242,9 @@ function stripOutTemporaryFields(imagesArray: ImageElement[]): ImageElement[] {
 /**
  * Clean up the displayed file name
  * (1) remove extension
- * (2) replace underscores with spaces
- * (3) replace periods with spaces
- * (4) tripple & double spaces become single spaces
+ * (2) replace underscores with spaces                "_"   => " "
+ * (3) replace periods with spaces                    "."   => " "
+ * (4) tripple & double spaces become single spaces   "   " => " "
  * @param original {string}
  * @return {string}
  */

--- a/src/app/components/sheet/sheet.component.html
+++ b/src/app/components/sheet/sheet.component.html
@@ -52,7 +52,7 @@
     <div class="copy-to-clipboard">
       <app-icon [icon]="'icon-clipboard'"></app-icon>
     </div>
-    <span [innerHtml]="selectedSourceFolder + video.partialPath + '/' + video.fileName | folderArrowsPipe"></span>
+    <span [innerHtml]="pathToVideoFile | folderArrowsPipe"></span>
   </div>
 
   <ng-container
@@ -73,7 +73,7 @@
         (click)="openVideoAtTime.emit({ mouseEvent: $event, thumbIndex: i })"
         [ngStyle]="{
             height: '100%',
-            'background-image': 'url(' + fullFilePath + ')',
+            'background-image': 'url(' + pathToFilmstripJpg + ')',
             'background-position-x': (percentOffset * i) + '%'
           }"
       >

--- a/src/app/components/sheet/sheet.component.ts
+++ b/src/app/components/sheet/sheet.component.ts
@@ -67,10 +67,11 @@ export class SheetComponent implements OnInit {
   @Input() showMeta: boolean;
   @Input() star: StarRating;
 
+  pathToFilmstripJpg: string;
+  pathToVideoFile: string;
   percentOffset: number = 0;
-  fullFilePath = '';
-  thumbnailsToDisplay = 4;
   starRatingHack: StarRating;
+  thumbnailsToDisplay = 4;
 
   constructor(
     public manualTagsService: ManualTagsService,
@@ -79,7 +80,8 @@ export class SheetComponent implements OnInit {
   ) { }
 
   ngOnInit() {
-    this.fullFilePath = this.filePathService.createFilePath(this.folderPath, this.hubName, 'filmstrips', this.video.hash);
+    this.pathToFilmstripJpg = this.filePathService.createFilePath(this.folderPath, this.hubName, 'filmstrips', this.video.hash);
+    this.pathToVideoFile = path.join(this.selectedSourceFolder, this.video.partialPath, this.video.fileName);
     this.percentOffset = (100 / (this.video.screens - 1));
     this.starRatingHack = this.star;
   }
@@ -136,8 +138,7 @@ export class SheetComponent implements OnInit {
   }
 
   copyToClipboard(): void {
-    const fullPath = path.join(this.selectedSourceFolder, this.video.partialPath, this.video.fileName);
-    navigator.clipboard.writeText(fullPath);
+    navigator.clipboard.writeText(this.pathToVideoFile);
   }
 
   /**

--- a/src/app/components/tags-auto/autotags.service.ts
+++ b/src/app/components/tags-auto/autotags.service.ts
@@ -10,8 +10,8 @@ export interface WordAndFreq {
   prefix: string; // filled in inside alphabetPrefixPipe
 }
 
-// Strip out: {}()[] as well as 'for', 'her', 'the', 'him', 'and', '-', & ','
-export const autoFileTagsRegex = /{|}|\(|\)|\[|\]|\b(for|her|the|him|and)\b|,|-/gi;
+// Used to strip out: all non-words, e.g. {}()[]-,.
+export const autoFileTagsRegex: RegExp = /\b(\w+)\b/g;
 
 @Injectable()
 export class AutoTagsService {
@@ -84,7 +84,7 @@ export class AutoTagsService {
    */
   private storeFinalArrayInMemory(finalArray: ImageElement[]): void {
     finalArray.forEach((element) => {
-      const cleanedFileName: string = element.cleanName.toLowerCase().replace(autoFileTagsRegex, '');
+      const cleanedFileName: string = (element.cleanName.toLowerCase().match(autoFileTagsRegex) || []).join(' ');
 
       this.onlyFileNames.push(cleanedFileName);
       this.addString(cleanedFileName);

--- a/src/app/components/tags-auto/tag-display.pipe.ts
+++ b/src/app/components/tags-auto/tag-display.pipe.ts
@@ -36,8 +36,8 @@ export class TagsDisplayPipe implements PipeTransform {
     }
 
     if (autoFileTags) {
-      const cleanedFileName: string = video.cleanName.toLowerCase().replace(autoFileTagsRegex, '');
-      cleanedFileName.split(' ').forEach(word => {
+      const cleanedFileNameAsArray: string[] = video.cleanName.toLowerCase().match(autoFileTagsRegex) || [];
+      cleanedFileNameAsArray.forEach(word => {
         if (word.length >= 3) { // TODO - fix hardcoding ?
           tags.push({name: word, colour: Colors.autoFileTags, removable: false});
         }

--- a/src/app/components/tags-auto/tags.component.html
+++ b/src/app/components/tags-auto/tags.component.html
@@ -81,7 +81,7 @@
       (change)="selectMinFrequency($event.target.value)"
       type="number"
       class="num-select"
-      value=4
+      value=0
       min=0
       max=50
     >

--- a/src/app/components/tags-auto/tags.component.ts
+++ b/src/app/components/tags-auto/tags.component.ts
@@ -38,7 +38,7 @@ export class TagsComponent implements OnInit, OnDestroy {
   statusMessage: string = '';
   showingStatusMessage: boolean = false;
 
-  minimumFrequency: number = 4;
+  minimumFrequency: number = 0;
 
   constructor(
     public tagsService: AutoTagsService,

--- a/src/app/pipes/delete-file.pipe.ts
+++ b/src/app/pipes/delete-file.pipe.ts
@@ -14,8 +14,6 @@ export class DeleteFilePipe implements PipeTransform {
    */
   transform(finalArray: ImageElement[], toggleHack: boolean): ImageElement[] {
 
-    console.log('delete pipe running!');
-
     return finalArray.filter(element => !element.deleted);
 
   }

--- a/src/app/pipes/word-frequency.service.ts
+++ b/src/app/pipes/word-frequency.service.ts
@@ -32,11 +32,10 @@ export class WordFrequencyService {
    * @param filename
    */
   public addString(filename: string): void {
-    filename = filename.replace(autoFileTagsRegex, '');
-    const wordArray = filename.split(' ');
+    const wordArray: string[] = filename.toLowerCase().match(autoFileTagsRegex) || [];
     wordArray.forEach(word => {
-      if (!(word.length < 3)) {
-        this.addWord(word.toLowerCase());
+      if (word.length >= 3) {
+        this.addWord(word);
       }
     });
   }
@@ -54,7 +53,7 @@ export class WordFrequencyService {
   }
 
   /**
-   * Remove all elements with 3 or fewer occurences
+   * Remove all elements with 2 or fewer occurences
    */
   public cleanMap(): void {
     this.wordMap.forEach((value, key) => {


### PR DESCRIPTION
Closes #307 

😅 Should have been doing `\b` all this time

Fixes:
- the occasional `>>` in the path to video file in details modal
- uses `\b` regex to find word boundaries rather than manual search for `{`, `[`, `(` and the like 🏊 


Now auto-tags will recognize, for example, all these as a "Tom Cruise":
- tom cruise
- tom    cruise
- tom-cruise
- tom----cruise
- tom_cruise 
    - (this happens because `cleanUpFileName` method will initially remove `_` first from `cleanName`)