### PR TITLE
Taskbar Shutdown Hook (#385)

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -648,10 +648,18 @@ ipc.on('close-window', (event, settingsToSave: SettingsObject, savableProperties
       writeVhaFileToDisk(lastSavedFinalObject, globals.currentlyOpenVhaFile, () => {
         // file writing done !!!
         console.log('.vha2 file written before closing !!!');
-        BrowserWindow.getFocusedWindow().close();
+        try {
+          BrowserWindow.getFocusedWindow().close();
+        } catch (e) {
+          // Window was already closed
+        }
       });
     } else {
-      BrowserWindow.getFocusedWindow().close();
+      try {
+        BrowserWindow.getFocusedWindow().close();
+      } catch (e) {
+        // Window was already closed
+      }
     }
   });
 });

--- a/src/app/components/home.component.ts
+++ b/src/app/components/home.component.ts
@@ -144,6 +144,7 @@ export class HomeComponent implements OnInit, AfterViewInit {
   // App state / UI state
   // ------------------------------------------------------------------------
 
+  isClosing = false;
   appMaximized = false;
   settingsModalOpen = false;
   finalArrayNeedsSaving: boolean = false; // if ever a file was renamed, or tag added, re-save the .vha2 file
@@ -535,6 +536,14 @@ export class HomeComponent implements OnInit, AfterViewInit {
       this.cd.detectChanges();
     });
 
+    // Closing of Window was issued by Electron
+    this.electronService.remote.getCurrentWindow().on('close', () => {
+      // Check to see if this was not originally triggered by Title-Bar to avoid double saving of settings
+      if (!this.isClosing) {
+        this.initiateClose();
+      }
+    });
+
     // Rename file response
     this.electronService.ipcRenderer.on(
       'renameFileResponse', (event, index: number, success: boolean, renameTo: string, oldFileName: string, errMsg?: string) => {
@@ -879,6 +888,7 @@ export class HomeComponent implements OnInit, AfterViewInit {
   }
 
   public initiateClose(): void {
+    this.isClosing = true;
     this.savePreviousViewSize();
     this.appState.imgsPerRow = this.imgsPerRow;
     this.electronService.ipcRenderer.send('close-window', this.getSettingsForSave(), this.saveVhaIfNeeded());

--- a/src/app/providers/electron.service.ts
+++ b/src/app/providers/electron.service.ts
@@ -5,6 +5,7 @@ import { Injectable } from '@angular/core';
 import { ipcRenderer } from 'electron';
 import * as childProcess from 'child_process';
 import { webFrame } from 'electron';
+import { remote } from 'electron';
 
 @Injectable()
 export class ElectronService {
@@ -12,12 +13,14 @@ export class ElectronService {
   ipcRenderer: typeof ipcRenderer;
   childProcess: typeof childProcess;
   webFrame: typeof webFrame;
+  remote: typeof remote;
 
   constructor() {
     // Conditional imports
     if (this.isElectron()) {
       this.ipcRenderer = window.require('electron').ipcRenderer;
       this.webFrame = window.require('electron').webFrame;
+      this.remote = window.require('electron').remote;
       this.childProcess = window.require('child_process');
     }
   }


### PR DESCRIPTION
Added shutdown hook to save settings and tags when app is closed from taskbar issue #385 

- Looks like this solves for Windows. 
- Need someone to test Mac. 