### PR TITLE
Windows 10 maximize, close, reopen position incorrect (#413)

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -629,7 +629,7 @@ ipc.on('choose-output', (event) => {
 ipc.on('close-window', (event, settingsToSave: SettingsObject, savableProperties: SavableProperties) => {
 
   // save window size and position
-  settingsToSave.windowSizeAndPosition = win.getBounds();
+  settingsToSave.windowSizeAndPosition = win.getContentBounds();
 
   const json = JSON.stringify(settingsToSave);
 


### PR DESCRIPTION
Solves issue #413 for Windows 10. Will need someone to test this on the other supported OS's though, as I don't know how these changes react on Mac or Linux. 

Issue was a combination of :
- instantiating our main `BrowserWindow` with param `frame=false`
- exporting the window bounds using `getBounds()` which seems to include the `x` , `y` coordinates of the hidden frame which had a value of `-8px` , `-8px` 

Using `getContentBounds()`, instead, exports correct coordinates for next startup.

Therefore, the very first startup with this fix will **still** incorrectly position the application because coordinates saved in the settings file are `-8px`, `-8px`. But the next startup will be ok after saving updated coordinates.
