### PR TITLE
Support video player launch arguments

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -214,6 +214,7 @@
     "changeLanguage": "Change language",
     "checkNewVersion": "check for new version",
     "chooseVideoPlayer": "change",
+    "playerArgs": "Player launch arguments",
     "clipsHeading": "Clips view",
     "closeRelatedTray": "Close related tray",
     "closeSettings": "Close settings",

--- a/src/app/common/app-state.ts
+++ b/src/app/common/app-state.ts
@@ -52,6 +52,7 @@ export const AppState: AppStateInterface = { // AppState is saved into `settings
   menuHidden: false,
   numOfFolders: 0,
   preferredVideoPlayer: '',
+  videoPlayerArgs: '',
   selectedOutputFolder: '',
   selectedSourceFolder: {},
   sortTagsByFrequency: false
@@ -68,6 +69,7 @@ export interface AppStateInterface {
   menuHidden: boolean;
   numOfFolders: number;
   preferredVideoPlayer: string;
+  videoPlayerArgs: string,
   selectedOutputFolder: string;
   selectedSourceFolder: InputSources;
   sortTagsByFrequency: boolean; // when `false` sort tags alphabetically

--- a/src/app/components/settings/settings.component.html
+++ b/src/app/components/settings/settings.component.html
@@ -96,6 +96,19 @@
 
     </div>
 
+    <div class="player-settings">
+
+      <input
+        class="filter-general input-filter"
+        [(ngModel)]="appState.videoPlayerArgs"
+        *ngIf="appState.preferredVideoPlayer"
+        placeholder="{{ 'SETTINGS.playerArgs' | translate }}"
+        type="text"
+        style="width: 400px"
+      >
+
+    </div>
+
     <span class="setting-heading">{{ 'SETTINGS.changeAppZoom' | translate }}</span>
 
     <div class="zoom-buttons">

--- a/src/app/components/settings/settings.component.ts
+++ b/src/app/components/settings/settings.component.ts
@@ -7,6 +7,7 @@ import { SettingsMetaGroup, SettingsMetaGroupLabels, SettingsButtonsType } from 
   styleUrls: [
     '../buttons.scss',
     '../settings.scss',
+    '../search-input.scss',
     './settings.component.scss'
   ]
 })


### PR DESCRIPTION
Partially support launching video player with arguments. Currently only load the arguments from `videoPlayerArgs` key in settings.json. UI needs to be implemented.