### PR TITLE
Support video player launch arguments

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -214,6 +214,7 @@
     "changeLanguage": "Change language",
     "checkNewVersion": "check for new version",
     "chooseVideoPlayer": "change",
+    "playerArgs": "Player launch arguments",
     "clipsHeading": "Clips view",
     "closeRelatedTray": "Close related tray",
     "closeSettings": "Close settings",

--- a/node/main-ipc.ts
+++ b/node/main-ipc.ts
@@ -6,7 +6,7 @@ const shell = require('electron').shell;
 import * as path from 'path';
 const fs = require('fs');
 const trash = require('trash');
-const spawn = require('child_process').spawn;
+const exec = require('child_process').exec;
 
 import { GLOBALS } from './main-globals';
 import { ImageElement, FinalObject } from '../interfaces/final-object.interface';
@@ -93,12 +93,10 @@ export function setUpIpcMessages(ipc, win, pathToAppData, systemMessages) {
   /**
    * Open a particular video file clicked inside Angular
    */
-  ipc.on('open-media-file-at-timestamp', (event, executablePath, fullFilePath: string, argz: string[]) => {
-    const allArgs: string[] = [];
-    allArgs.push(path.normalize(fullFilePath));
-    allArgs.push(...argz);
+  ipc.on('open-media-file-at-timestamp', (event, executablePath, fullFilePath: string, args: string) => {
+    const allArgs: string = path.normalize(fullFilePath) + (args ? ' ' + args : '');
     console.log(allArgs);
-    spawn(path.normalize(executablePath), allArgs);
+    exec(path.normalize(executablePath) + ' ' + allArgs);
   });
 
   /**

--- a/src/app/common/app-state.ts
+++ b/src/app/common/app-state.ts
@@ -52,6 +52,7 @@ export const AppState: AppStateInterface = { // AppState is saved into `settings
   menuHidden: false,
   numOfFolders: 0,
   preferredVideoPlayer: '',
+  videoPlayerArgs: '',
   selectedOutputFolder: '',
   selectedSourceFolder: {},
   sortTagsByFrequency: false
@@ -68,6 +69,7 @@ export interface AppStateInterface {
   menuHidden: boolean;
   numOfFolders: number;
   preferredVideoPlayer: string;
+  videoPlayerArgs: string,
   selectedOutputFolder: string;
   selectedSourceFolder: InputSources;
   sortTagsByFrequency: boolean; // when `false` sort tags alphabetically

--- a/src/app/components/home.component.ts
+++ b/src/app/components/home.component.ts
@@ -863,7 +863,8 @@ export class HomeComponent implements OnInit, AfterViewInit {
 
       const execPath: string = this.appState.preferredVideoPlayer;
 
-      this.electronService.ipcRenderer.send('open-media-file-at-timestamp', execPath, fullPath, this.getVideoPlayerArgs(execPath, time));
+      const finalArgs: string = this.getVideoPlayerArgs(execPath, time) + (this.appState.videoPlayerArgs ? ' ' + this.appState.videoPlayerArgs : '');
+      this.electronService.ipcRenderer.send('open-media-file-at-timestamp', execPath, fullPath, finalArgs);
     } else {
       this.electronService.ipcRenderer.send('open-media-file', fullPath);
     }
@@ -874,27 +875,23 @@ export class HomeComponent implements OnInit, AfterViewInit {
    * @param playerPath  full path to user's preferred video player
    * @param time        time in seconds
    */
-  public getVideoPlayerArgs(playerPath: string, time: number): string[] {
+  public getVideoPlayerArgs(playerPath: string, time: number): string {
     // if user doesn't want to open at timestamp, don't!
-    if (!this.settingsButtons['openAtTimestamp'].toggled) {
-      return [];
+    let args: string;
+
+    if (this.settingsButtons['openAtTimestamp'].toggled) {
+      if (playerPath.toLowerCase().includes('vlc')) {
+        args = '--start-time=' + time.toString();    // in seconds
+
+      } else if (playerPath.toLowerCase().includes('mpc')) {
+        args = '/start ' + (1000 * time).toString(); // in milliseconds
+
+      } else if (playerPath.toLowerCase().includes('pot')) {
+        args = '/seek=' + time.toString();           // in seconds
+      }
     }
 
-    // else, figure out the correct command line flags
-    const argz: string[] = [];
-
-    if (playerPath.toLowerCase().includes('vlc')) {
-      argz.push('--start-time=' + time.toString()); // in seconds
-
-    } else if (playerPath.toLowerCase().includes('mpc')) {
-      argz.push('/start');
-      argz.push((1000 * time).toString());          // in milliseconds
-
-    } else if (playerPath.toLowerCase().includes('pot')) {
-      argz.push('/seek=' + time.toString());        // in seconds
-    }
-
-    return argz;
+    return args;
   }
 
   public openOnlineHelp(): void {

--- a/src/app/components/settings/settings.component.html
+++ b/src/app/components/settings/settings.component.html
@@ -96,6 +96,19 @@
 
     </div>
 
+    <div class="player-settings">
+
+      <input
+        class="filter-general input-filter"
+        [(ngModel)]="appState.videoPlayerArgs"
+        *ngIf="appState.preferredVideoPlayer"
+        placeholder="{{ 'SETTINGS.playerArgs' | translate }}"
+        type="text"
+        style="width: 400px"
+      >
+
+    </div>
+
     <span class="setting-heading">{{ 'SETTINGS.changeAppZoom' | translate }}</span>
 
     <div class="zoom-buttons">

--- a/src/app/components/settings/settings.component.ts
+++ b/src/app/components/settings/settings.component.ts
@@ -7,6 +7,7 @@ import { SettingsMetaGroup, SettingsMetaGroupLabels, SettingsButtonsType } from 
   styleUrls: [
     '../buttons.scss',
     '../settings.scss',
+    '../search-input.scss',
     './settings.component.scss'
   ]
 })


### PR DESCRIPTION
Add an input box in the settings page for video player launch arguments. The custom argument string along with automatically generated timestamp arguments are passed to the launched video player. The custom arguments are also saved in the "videoPlayerArgs" key in settings.json.