### PR TITLE
Properly handle video path with spaces

### DIFF
--- a/node/main-ipc.ts
+++ b/node/main-ipc.ts
@@ -94,9 +94,9 @@ export function setUpIpcMessages(ipc, win, pathToAppData, systemMessages) {
    * Open a particular video file clicked inside Angular
    */
   ipc.on('open-media-file-at-timestamp', (event, executablePath, fullFilePath: string, args: string) => {
-    const allArgs: string = path.normalize(fullFilePath) + (args ? ' ' + args : '');
-    console.log(allArgs);
-    exec(path.normalize(executablePath) + ' ' + allArgs);
+    const cmdline: string = `"${path.normalize(executablePath)}" "${path.normalize(fullFilePath)}" ${args}`;
+    console.log(cmdline);
+    exec(cmdline);
   });
 
   /**

--- a/src/app/components/home.component.ts
+++ b/src/app/components/home.component.ts
@@ -863,7 +863,7 @@ export class HomeComponent implements OnInit, AfterViewInit {
 
       const execPath: string = this.appState.preferredVideoPlayer;
 
-      const finalArgs: string = this.getVideoPlayerArgs(execPath, time) + (this.appState.videoPlayerArgs ? ' ' + this.appState.videoPlayerArgs : '');
+      const finalArgs: string = `${this.getVideoPlayerArgs(execPath, time)} ${this.appState.videoPlayerArgs}`;
       this.electronService.ipcRenderer.send('open-media-file-at-timestamp', execPath, fullPath, finalArgs);
     } else {
       this.electronService.ipcRenderer.send('open-media-file', fullPath);
@@ -877,7 +877,7 @@ export class HomeComponent implements OnInit, AfterViewInit {
    */
   public getVideoPlayerArgs(playerPath: string, time: number): string {
     // if user doesn't want to open at timestamp, don't!
-    let args: string;
+    let args: string = '';
 
     if (this.settingsButtons['openAtTimestamp'].toggled) {
       if (playerPath.toLowerCase().includes('vlc')) {


### PR DESCRIPTION
My last change switched from `spawn()` to `exec()`, which uses shell to open files. Thus if the path contains spaces and not quoted, the file will not be found. This quotes both the video player and video file, and should fix that problem. Sorry about that.