### PR TITLE
use polling only on network drives

### DIFF
--- a/node/main-extract-async.ts
+++ b/node/main-extract-async.ts
@@ -170,7 +170,7 @@ export function startFileSystemWatching(
     cwd: inputDir,
     disableGlobbing: true,
     persistent: persistent,
-    usePolling: true, // neccessary for files over network
+    usePolling: inputDir.startsWith('//') ? true : false, // neccessary for files over network
   }
 
   const watcher: FSWatcher = chokidar.watch(inputDir, watcherConfig);


### PR DESCRIPTION
Should close #515 🤞 

Whenever we detect the path starts with `//` we can assume it's a network path, and we should use `polling` in _chokidar_ 🤔 