### PR TITLE
Use birthtimeMs instead of ctimeMs as file created time

### DIFF
--- a/interfaces/final-object.interface.ts
+++ b/interfaces/final-object.interface.ts
@@ -33,7 +33,7 @@ export interface ImageElement {
   height: AllowedScreenshotHeight; // height of the video (px)
   inputSource: number;           // corresponding to `inputDirs`
   mtime: number;                 // file modification time
-  ctime: number;                 // file creation time
+  birthtime: number;             // file creation time
   partialPath: string;           // for opening the file, just prepend the `inputDir` (starts with "/", is "/fldr1/fldr2", or can be "")
   screens: number;               // number of screenshots for this file
   stars: StarRating;             // star rating 0 = n/a, otherwise 1, 2, 3
@@ -76,7 +76,7 @@ export function NewImageElement(): ImageElement {
     index: 0,
     inputSource: 0,
     mtime: 0,
-    ctime: 0,
+    birthtime: 0,
     partialPath: '',
     resBucket: 0,
     resolution: '',

--- a/node/archive.ts
+++ b/node/archive.ts
@@ -464,7 +464,7 @@ function extractMetadataForThisONEFile(
       imageElement.duration = duration;
       imageElement.fileSize = stat.size;
       imageElement.mtime = stat.mtimeMs;
-      imageElement.ctime = stat.ctimeMs;
+      imageElement.birthtime = stat.birthtimeMs;
       if (imageElement.hash === '') {
         imageElement.hash = hashFile(filePath);
       }

--- a/node/main-support.ts
+++ b/node/main-support.ts
@@ -379,7 +379,7 @@ export function extractMetadataAsync(
         const origWidth = stream.width || 0; // ffprobe does not detect it on some MKV streams
         const origHeight = stream.height || 0;
 
-        imageElement.ctime = fileStat.ctimeMs;
+        imageElement.birthtime = fileStat.birthtimeMs;
         imageElement.duration = duration;
         imageElement.fileSize = fileStat.size;
         imageElement.height = origHeight;

--- a/src/app/pipes/folder-view.pipe.ts
+++ b/src/app/pipes/folder-view.pipe.ts
@@ -7,7 +7,7 @@ interface FolderProperties {
   byteSize: number;    //                             corresponds to ImageElement `fileSize`
   duration: number;    // in seconds,                 corresponds to ImageElement `duration`
   mtime: number; //                                   corresponds to ImageElement `mtime`
-  ctime: number; //                                   corresponds to ImageElement `ctime`
+  birthtime: number; //                                   corresponds to ImageElement `birthtime`
   starAverage: StarRating; // averaged weight of stars rounded to nearest `StarRating`
 }
 
@@ -36,8 +36,8 @@ export class FolderViewPipe implements PipeTransform {
       if (element.mtime > lastUpdated) {
         lastUpdated = element.mtime;
       }
-      if (element.ctime < firstCreated) {
-        firstCreated = element.ctime;
+      if (element.birthtime < firstCreated) {
+        firstCreated = element.birthtime;
       }
       if (element.stars !== 0.5) {
         totalStars += 1;
@@ -52,7 +52,7 @@ export class FolderViewPipe implements PipeTransform {
       byteSize: totalFileSize,
       duration: totalDuration,
       mtime: lastUpdated,
-      ctime: firstCreated,
+      birthtime: firstCreated,
       starAverage: starString,
     };
   }
@@ -217,7 +217,7 @@ export class FolderViewPipe implements PipeTransform {
           folderWithStuff.hash            = this.extractFourPreviewHashes(value),
           folderWithStuff.index           = -1, // always show at the top (but after the `UP` folder) in the default view
           folderWithStuff.mtime           = folderProperties.mtime,
-          folderWithStuff.ctime           = folderProperties.ctime,
+          folderWithStuff.birthtime       = folderProperties.birthtime,
           folderWithStuff.partialPath     = (prefixPath || '/') + key, // must set this for the folder click to register!
           folderWithStuff.stars           = folderProperties.starAverage,
 

--- a/src/app/pipes/sorting.pipe.ts
+++ b/src/app/pipes/sorting.pipe.ts
@@ -235,11 +235,11 @@ export class SortingPipe implements PipeTransform {
       });
     } else if (sortingType === 'createdAsc') {
       return galleryArray.slice().sort((x: ImageElement, y: ImageElement): any => {
-        return this.sortFunctionLol(x, y, 'ctime', true);
+        return this.sortFunctionLol(x, y, 'birthtime', true);
       });
     } else if (sortingType === 'createdDesc') {
       return galleryArray.slice().sort((x: ImageElement, y: ImageElement): any => {
-        return this.sortFunctionLol(x, y, 'ctime', false);
+        return this.sortFunctionLol(x, y, 'birthtime', false);
       });
     } else if (sortingType === 'hash') {
       return galleryArray.slice().sort((x: ImageElement, y: ImageElement): any => {


### PR DESCRIPTION
I'm sorry I made a mistake in https://github.com/whyboris/Video-Hub-App/commit/3e58686fc2015efe13adb76f66ba10eefd762eca that I used `ctimeMs` as file created time. According to [the document](https://nodejs.org/api/fs.html#fs_stats_birthtimems), `birthtimeNs` is the correct property name. `ctime` stands for "change time", just like the [Linux equivalent](https://linux.die.net/man/2/stat).

I tested the change. Should be OK now.