### PR TITLE
auto file tags fix

### DIFF
--- a/src/app/components/home.component.html
+++ b/src/app/components/home.component.html
@@ -369,8 +369,12 @@
           'height': 'calc(100vh - ' + (
                         appState.menuHidden | sidebarHeightPipe
                           : settingsButtons['hideTop'].toggled
-                          : settingsButtons['showRelatedVideosTray'].toggled
-                          : settingsButtons['showTagTray'].toggled
+                          : (
+                                 settingsButtons['showRelatedVideosTray'].toggled
+                              || settingsButtons['showRecentlyPlayed'].toggled
+                              || settingsButtons['showTagTray'].toggled
+                              || settingsButtons['showFreq'].toggled
+                            )
                       ) + 'px)'
         }"
       #searchRef
@@ -618,12 +622,16 @@
       class="gallery-container"
 
       [ngStyle]="{
-        'height': 'calc(100vh - ' + (
-                      appState.menuHidden | sidebarHeightPipe
-                        : settingsButtons['hideTop'].toggled
-                        : settingsButtons['showRelatedVideosTray'].toggled
-                        : settingsButtons['showTagTray'].toggled
-                    ) + 'px)'
+          'height': 'calc(100vh - ' + (
+                        appState.menuHidden | sidebarHeightPipe
+                          : settingsButtons['hideTop'].toggled
+                          : (
+                                 settingsButtons['showRelatedVideosTray'].toggled
+                              || settingsButtons['showRecentlyPlayed'].toggled
+                              || settingsButtons['showTagTray'].toggled
+                              || settingsButtons['showFreq'].toggled
+                            )
+                      ) + 'px)'
         }"
 
       [enableUnequalChildrenSizes]="appState.currentView === 'showFullView'"

--- a/src/app/components/home.component.html
+++ b/src/app/components/home.component.html
@@ -163,7 +163,7 @@
     </div>
     <app-tags-component
       [hubName]="appState.hubName"
-      (tagClicked)="tagClicked($event)"
+      (tagClicked)="autoTagClicked($event)"
     ></app-tags-component>
   </div>
 

--- a/src/app/components/home.component.html
+++ b/src/app/components/home.component.html
@@ -972,6 +972,7 @@
 <div
   class="all-settings-tabs bottom-tray-tabs"
   [ngClass]="{
+    'bottom-tray-tabs-dark': settingsButtons['darkMode'].toggled,
     'bottom-tray-tabs-open': settingsButtons['showRelatedVideosTray'].toggled
                           || settingsButtons['showRecentlyPlayed'].toggled
                           || settingsButtons['showTagTray'].toggled
@@ -1013,6 +1014,7 @@
 
 <div
   class="bottom-tray"
+  [ngClass]="{ 'bottom-tray-dark': settingsButtons['darkMode'].toggled }"
   *ngIf="settingsButtons['showRelatedVideosTray'].toggled
       || settingsButtons['showRecentlyPlayed'].toggled
       || settingsButtons['showTagTray'].toggled

--- a/src/app/components/home.component.ts
+++ b/src/app/components/home.component.ts
@@ -1269,8 +1269,14 @@ export class HomeComponent implements OnInit, AfterViewInit {
     this.wizard.showWizard = false;
   }
 
-  tagClicked(event: string): void {
-    this.filters[3].array = []; // clear search array
+  /**
+   * Handle auto-generated tag clicked: add it to file search filter
+   * @param event
+   */
+  autoTagClicked(event: string): void {
+    if (!this.settingsButtons['autoFileTags'].toggled) {
+      this.settingsButtons['autoFileTags'].toggled = true;
+    }
     this.handleTagWordClicked(event);
     this.toggleButton('showTags'); // close the modal
   }

--- a/src/app/components/layout.scss
+++ b/src/app/components/layout.scss
@@ -308,6 +308,18 @@
   }
 }
 
+.bottom-tray-tabs-dark {
+  button {
+    background: black !important;
+    border: 1px solid #333333 !important;
+    color: white;
+  }
+
+  .active-tab {
+    border-bottom: 1px solid black !important;
+  }
+}
+
 .no-results {
   box-sizing: border-box;
   position: absolute;

--- a/src/app/components/similar-tray/similar-tray.component.html
+++ b/src/app/components/similar-tray/similar-tray.component.html
@@ -1,6 +1,5 @@
 <div
   class="most-similar-tray"
-  [ngClass]="{ 'bottom-tray-dark': settingsButtons['darkMode'].toggled }"
 >
 
   <div

--- a/src/app/components/tag-tray/tag-tray.component.html
+++ b/src/app/components/tag-tray/tag-tray.component.html
@@ -20,6 +20,7 @@
       (keyup.esc)="manualTagFilterString = ''"
       [(ngModel)]="manualTagFilterString"
       class="filter-general manual-tag-tray-filter"
+      [ngClass]="{ 'manual-tag-tray-filter-dark': settingsButtons['darkMode'].toggled }"
       placeholder="{{ 'TAGS.filterTags' | translate }}"
     >
 
@@ -34,11 +35,12 @@
         {{ 'TAGS.clickTagToAdd' | translate }}
       </span>
       <button
-      class="wizard-button wizard-button-small"
-      (click)="selectAll.emit()"
-    >
-      {{ 'TAGS.selectAllButton' | translate }}
-    </button>
+        class="wizard-button wizard-button-small"
+        [ngClass]="{ 'select-all-dark': settingsButtons['darkMode'].toggled }"
+        (click)="selectAll.emit()"
+      >
+        {{ 'TAGS.selectAllButton' | translate }}
+      </button>
     </div>
   </ng-template>
 

--- a/src/app/components/tag-tray/tag-tray.component.html
+++ b/src/app/components/tag-tray/tag-tray.component.html
@@ -1,6 +1,5 @@
 <div
   class="manual-tag-tray"
-  [ngClass]="{ 'bottom-tray-dark': settingsButtons['darkMode'].toggled }"
 >
   <div class="tag-tray-menu-left" *ngIf="!batchTaggingMode; else batchModeExplainer">
     <button
@@ -45,7 +44,11 @@
 
   <button
     class="wizard-button wizard-button-small button-toggle-batch-mode"
-    [ngClass]="{ 'edit-mode-active': batchTaggingMode }"
+    [ngClass]="{
+      'button-toggle-batch-mode-dark': settingsButtons['darkMode'].toggled,
+      'button-toggle-batch-mode-dark-active': settingsButtons['darkMode'].toggled && batchTaggingMode,
+      'edit-mode-active': batchTaggingMode
+    }"
     (click)="toggleBatchTaggingMode.emit()"
   >
     {{ 'TAGS.batchModeButton' | translate }}

--- a/src/app/components/tag-tray/tag-tray.component.scss
+++ b/src/app/components/tag-tray/tag-tray.component.scss
@@ -55,6 +55,14 @@
       color: $gray-80;
     }
   }
+
+  .manual-tag-tray-filter-dark {
+    color: white;
+
+    &::placeholder {
+      color: $gray-20;
+    }
+  }
 }
 
 .button-toggle-batch-mode {
@@ -67,9 +75,27 @@
 .button-toggle-batch-mode-dark {
   background: #333333;
   color: white !important;
+
+  &:hover {
+    background: #555555;
+  }
 }
 
 .button-toggle-batch-mode-dark-active {
   background: $pretty-red;
   color: black !important;
+
+  &:hover {
+    background-color: $pretty-red-lighter;
+  }
+}
+
+.select-all-dark {
+  background: #333333;
+  border: 1px solid #888888;
+  color: white;
+
+  &:hover {
+    background: #555555;
+  }
 }

--- a/src/app/components/tag-tray/tag-tray.component.scss
+++ b/src/app/components/tag-tray/tag-tray.component.scss
@@ -63,3 +63,13 @@
   left: 9px;
   position: absolute;
 }
+
+.button-toggle-batch-mode-dark {
+  background: #333333;
+  color: white !important;
+}
+
+.button-toggle-batch-mode-dark-active {
+  background: $pretty-red;
+  color: black !important;
+}

--- a/src/app/components/tags-auto/tags.component.ts
+++ b/src/app/components/tags-auto/tags.component.ts
@@ -62,6 +62,7 @@ export class TagsComponent implements OnInit, OnDestroy {
 
   /**
    * Emit string to home component to search for this string
+   * if in `editMode` update tags accordingly
    */
   tagWasClicked(tag: string): void {
     if (this.editMode) {

--- a/src/app/pipes/sidebar-height.pipe.ts
+++ b/src/app/pipes/sidebar-height.pipe.ts
@@ -7,20 +7,20 @@ export class SidebarHeightPipe implements PipeTransform {
 
   /**
    * Return number of pixels to offset the sidebar (as a string)
-   * @param finalArray
-   * @param searchString  the search string
+   * @param menuHidden     - whether to hide the menu bar
+   * @param hideTop        - whether to hide the top bar
+   * @param showBottomTray - whether the bottom tray is showing
    */
   transform(
     menuHidden: boolean,
     hideTop: boolean,
-    showRelatedVideosTray: boolean,
-    showTagTray: boolean
+    showBottomTray: boolean
   ): string {
 
     return (
-        (menuHidden                             ? -32 :  0)
-      + (hideTop                                ?  53 : 98)
-      + ((showRelatedVideosTray || showTagTray) ? 170 :  0)
+        (menuHidden     ? -32 :  0)
+      + (hideTop        ?  53 : 98)
+      + (showBottomTray ? 170 :  0)
       ).toString();
 
   }


### PR DESCRIPTION
Now, when clicking on auto-generated tags, if the `autoFileTags` is not enabled, it will be toggled to `true` ✅ 

Else, there would be no search results showing up 😓 

This fixes the #403 😁 

Also:
 - resize the UI (gallery & sidebar) whenever the bottom tray is showing 👍 
 - Dark mode for the bottom tray 😎 