### PR TITLE
No duplicate items, even with rename, even while watching folder

### DIFF
--- a/node/main-extract-async.ts
+++ b/node/main-extract-async.ts
@@ -277,8 +277,9 @@ export function startFileSystemWatching(
       metadataQueue.push(newItem);
     })
     .on('unlink', (filePath: string) => {
-      console.log(' !!! FILE DELETED:', filePath);
-      console.log('TODO - UPDATE ANGULAR');
+      // note: this happens even when file is renamed!
+      console.log(' !!! FILE DELETED, updating Angular:', filePath);
+      GLOBALS.angularApp.sender.send('single-file-deleted', inputSource, filePath);
     })
     .on('unlinkDir', (folderPath: string) => {
       console.log(' !!!!! DIRECTORY DELETED:', folderPath);

--- a/node/main-extract-async.ts
+++ b/node/main-extract-async.ts
@@ -301,6 +301,7 @@ export function startFileSystemWatching(
         console.log('^^^^^^^^ - CONTINUING to watch this directory!');
       } else {
         console.log('^^^^^^^^ - stopping watching this directory');
+        watcher.close(); // chokidar seems to disregard `persistent` when `fsevents` is not enabled
       }
 
       const t1 = performance.now();

--- a/node/main-support.ts
+++ b/node/main-support.ts
@@ -167,6 +167,7 @@ function markDuplicatesAsDeleted(imagesArray: ImageElement[]): ImageElement[] {
       && element.inputSource === currentElement.inputSource
     ) {
       element.deleted = true;
+      console.log('DUPE FOUND: '+ element.fileName);
     }
     currentElement = element;
   });

--- a/node/main-support.ts
+++ b/node/main-support.ts
@@ -148,6 +148,7 @@ function countFoldersInFinalArray(imagesArray: ImageElement[]): number {
 
 /**
  * Mark element as `deleted` (to remove as duplicate) if the previous element is identical
+ * expect `alphabetizeFinalArray` to run first - so as to only compare adjacent elements
  * Unsure how duplicates can creep in to `ImageElement[]`, but at least they will be removed
  *
  *  !!! WARNING - currently does not merge the `tags` arrays (or other stuff)
@@ -161,9 +162,9 @@ function markDuplicatesAsDeleted(imagesArray: ImageElement[]): ImageElement[] {
 
   imagesArray.forEach((element: ImageElement) => {
     if (
-         element.inputSource === currentElement.inputSource
-      && element.fileName    === currentElement.fileName
+         element.fileName    === currentElement.fileName
       && element.partialPath === currentElement.partialPath
+      && element.inputSource === currentElement.inputSource
     ) {
       element.deleted = true;
     }
@@ -182,6 +183,9 @@ function markDuplicatesAsDeleted(imagesArray: ImageElement[]): ImageElement[] {
  * @param done          -- function to execute when done writing the file
  */
 export function writeVhaFileToDisk(finalObject: FinalObject, pathToTheFile: string, done): void {
+
+  finalObject.images = finalObject.images.filter(element => !element.deleted);
+
   finalObject.images = stripOutTemporaryFields(finalObject.images);
 
   // remove any videos that have no reference (unsure how this could happen, but just in case)
@@ -190,11 +194,9 @@ export function writeVhaFileToDisk(finalObject: FinalObject, pathToTheFile: stri
     return allKeys.includes(element.inputSource.toString());
   });
 
-  finalObject.images = alphabetizeFinalArray(finalObject.images); // TODO -- rethink if this is needed
-
-  finalObject.images = markDuplicatesAsDeleted(finalObject.images);
-
-  finalObject.images = finalObject.images.filter(element => !element.deleted);
+  finalObject.images = alphabetizeFinalArray(finalObject.images); // needed for `default` sort to show proper order
+  finalObject.images = markDuplicatesAsDeleted(finalObject.images); // expects `alphabetizeFinalArray` to run first
+  finalObject.images = finalObject.images.filter(element => !element.deleted); // remove any marked in above method
 
   finalObject.numOfFolders = countFoldersInFinalArray(finalObject.images);
 

--- a/src/app/components/home.component.html
+++ b/src/app/components/home.component.html
@@ -126,7 +126,7 @@
     [showMeta]="settingsButtons['showMoreInfo'].toggled"
     [showVideoNotes]="settingsButtons['showVideoNotes'].toggled"
 
-    [renameResponse]="this.renameFileResponseBehaviorSubject"
+    [renameResponse]="renameFileResponseBehaviorSubject"
   >
   </app-thumbnail-sheet>
 

--- a/src/app/components/home.component.ts
+++ b/src/app/components/home.component.ts
@@ -25,7 +25,7 @@ import { WordFrequencyService, WordFreqAndHeight } from '../pipes/word-frequency
 import { SortOrderComponent } from './sort-order/sort-order.component';
 
 // Interfaces
-import { FinalObject, ImageElement, ScreenshotSettings, ResolutionString, NewImageElement } from '../../../interfaces/final-object.interface';
+import { FinalObject, ImageElement, ScreenshotSettings, ResolutionString } from '../../../interfaces/final-object.interface';
 import { ImportStage } from '../../../node/main-support';
 import { SettingsObject } from '../../../interfaces/settings-object.interface';
 import { SortType } from '../pipes/sorting.pipe';

--- a/src/app/components/home.component.ts
+++ b/src/app/components/home.component.ts
@@ -25,7 +25,7 @@ import { WordFrequencyService, WordFreqAndHeight } from '../pipes/word-frequency
 import { SortOrderComponent } from './sort-order/sort-order.component';
 
 // Interfaces
-import { FinalObject, ImageElement, ScreenshotSettings, ResolutionString } from '../../../interfaces/final-object.interface';
+import { FinalObject, ImageElement, ScreenshotSettings, ResolutionString, NewImageElement } from '../../../interfaces/final-object.interface';
 import { ImportStage } from '../../../node/main-support';
 import { SettingsObject } from '../../../interfaces/settings-object.interface';
 import { SortType } from '../pipes/sorting.pipe';
@@ -294,6 +294,8 @@ export class HomeComponent implements OnInit, AfterViewInit {
 
   allFinishedScanning: boolean = true;
 
+  lastRenamedFileHack: ImageElement;
+
   // Behavior Subjects for IPC events:
 
   inputSorceChosenBehaviorSubject: BehaviorSubject<string> = new BehaviorSubject(undefined);
@@ -396,28 +398,6 @@ export class HomeComponent implements OnInit, AfterViewInit {
 
     }, 100);
 
-    this.electronService.ipcRenderer.on(
-      'rename-file-response', (
-          event,
-          index: number,
-          success: boolean,
-          renameTo: string,
-          oldFileName: string,
-          errMsg?: string
-        ) => {
-
-          this.renameFileResponseBehaviorSubject.next({
-            index: index,
-            success: success,
-            renameTo: renameTo,
-            oldFileName: oldFileName,
-            errMsg: errMsg,
-          });
-          this.renameFileResponseBehaviorSubject.next(undefined); // allways remove right away
-
-      });
-
-
     // for statistics.component
     this.electronService.ipcRenderer.on('number-of-screenshots-deleted', (event, totalDeleted: number) => {
       this.numberScreenshotsDeletedBehaviorSubject.next(totalDeleted);
@@ -476,7 +456,7 @@ export class HomeComponent implements OnInit, AfterViewInit {
       }
     });
 
-    // Rename file response
+    // When Node succeeds or fails to rename a file that Angular requested to rename
     this.electronService.ipcRenderer.on(
       'rename-file-response', (
           event,
@@ -487,12 +467,29 @@ export class HomeComponent implements OnInit, AfterViewInit {
           errMsg?: string
         ) => {
 
-      if (success) {
-        // Update the final array, close rename dialog if open
-        // the error messaging is handled by `rename-file.component` or `meta.component` if it happens
-        this.imageElementService.replaceFileNameInFinalArray(renameTo, oldFileName, index);
-        this.closeRename();
-      }
+          this.renameFileResponseBehaviorSubject.next({
+            index: index,
+            success: success,
+            renameTo: renameTo,
+            oldFileName: oldFileName,
+            errMsg: errMsg,
+          });
+          this.renameFileResponseBehaviorSubject.next(undefined); // allways remove right away
+
+          if (success) {
+            // Update the final array, close rename dialog if open
+            // the error messaging is handled by `rename-file.component` or `meta.component` if it happens
+            this.imageElementService.replaceFileNameInFinalArray(renameTo, oldFileName, index);
+            this.closeRename();
+
+            // if successful rename, and `watch` directory enabled, this video might appear twice
+            // use `lastRenamedFileHack` to prevent it!
+            const renamedFile: ImageElement = this.imageElementService.imageElements[index];
+            console.log('Rename success:');
+            console.log(renamedFile);
+            this.lastRenamedFileHack = renamedFile;
+          }
+
     });
 
     // happens when user replaced a thumbnail and process is done
@@ -587,6 +584,20 @@ export class HomeComponent implements OnInit, AfterViewInit {
 
     });
 
+    // When `watch` folder and `chokidar` detects a file was deleted (can happen when renamed too!)
+    this.electronService.ipcRenderer.on('single-file-deleted', (event, sourceIndex: number, partialPath: string) => {
+      this.imageElementService.imageElements
+        .filter((element: ImageElement) => { return element.inputSource == sourceIndex })
+        // notice the loosey-goosey comparison! this is because number  ^^  string comparison happening here!
+        .forEach((element: ImageElement) => {
+          if (('\\' + partialPath) === path.join(element.partialPath, element.fileName)) {
+            console.log('FILE DELETED !!!', partialPath);
+            element.deleted = true;
+            this.deletePipeHack = !this.deletePipeHack;
+          }
+        });
+    });
+
     /**
      * Update thumbnail extraction progress when node sends update
      * @param current - the current number that finished extracting
@@ -633,6 +644,8 @@ export class HomeComponent implements OnInit, AfterViewInit {
       pathToFile: string,
       outputFolderPath: string,
     ) => {
+
+      this.lastRenamedFileHack = undefined;
 
       this.imageElementService.recentlyPlayed = [];
 
@@ -736,6 +749,17 @@ export class HomeComponent implements OnInit, AfterViewInit {
     });
 
     this.electronService.ipcRenderer.on('new-video-meta', (event, element: ImageElement) => {
+
+      if (   this.lastRenamedFileHack // undefined unless file recently renamed
+          && this.lastRenamedFileHack.inputSource === element.inputSource
+          && this.lastRenamedFileHack.partialPath === element.partialPath
+          && this.lastRenamedFileHack.fileName    === element.fileName
+      ) {
+        // this video was just renamed, skip it
+        console.log('SKIPPING THIS -- was just renamed !!!');
+        return;
+      }
+
       element.index = this.imageElementService.imageElements.length;
       this.imageElementService.imageElements.push(element); // not enough for view to update; we need `.slice()`
       this.imageElementService.finalArrayNeedsSaving = true;

--- a/src/app/components/home.component.ts
+++ b/src/app/components/home.component.ts
@@ -567,6 +567,8 @@ export class HomeComponent implements OnInit, AfterViewInit {
 
       const rootFolder: string = this.sourceFolderService.selectedSourceFolder[sourceIndex].path;
 
+      let somethingDeleted: boolean = false;
+
       this.imageElementService.imageElements
         .filter((element: ImageElement) => { return element.inputSource == sourceIndex })
         // notice the loosey-goosey comparison! this is because number  ^^  string comparison happening here!
@@ -575,10 +577,13 @@ export class HomeComponent implements OnInit, AfterViewInit {
           if (!allFilesMap.has(path.join(rootFolder, element.partialPath, element.fileName))) {
             console.log('deleting');
             element.deleted = true;
+            somethingDeleted = true;
           }
         });
 
-      this.deletePipeHack = !this.deletePipeHack;
+      if (somethingDeleted) {
+        this.deletePipeHack = !this.deletePipeHack;
+      }
 
     });
 

--- a/src/app/components/meta/meta.component.ts
+++ b/src/app/components/meta/meta.component.ts
@@ -65,7 +65,7 @@ export class MetaComponent implements OnInit, OnDestroy {
 
     this.responseSubscription = this.renameResponse.subscribe((data: RenameFileResponse) => {
       if (data) {
-        console.log('WOW');
+        console.log('Rename response:');
         console.log(data);
 
         if (this.video.index === data.index) { // make sure the message is about current component's video

--- a/src/app/components/rename-file/rename-file.component.ts
+++ b/src/app/components/rename-file/rename-file.component.ts
@@ -51,7 +51,7 @@ export class RenameFileComponent implements OnInit, OnDestroy {
     this.responseSubscription = this.renameResponse.subscribe((data: RenameFileResponse) => {
 
       if (data) {
-        console.log('WOW !!!');
+        console.log('Rename response:');
         console.log(data);
 
         // just in case, make sure the message came back for the current file


### PR DESCRIPTION
Still a lot of work to do, but I'm focusing on the blockers before _release_ 🎉 

I'll look more into _how_ duplicates might appear, but at the very least I can crudely delete duplicates if needed:
 - Closes #557 
 - Closes #552 

With the last commit I think I solved the problem 😅 https://github.com/whyboris/Video-Hub-App/pull/573/commits/aa292b9899c5151ede9e13e40b2ce860cc0ab992

Though it's a bit of a hack - but it will likely work well enough.

Worst-case-scenario, the duplicates should disappear after closing and re-opening the hub 😁 🤝 😅 