### PR TITLE
Various cleanup

### DIFF
--- a/node/main-extract-async.ts
+++ b/node/main-extract-async.ts
@@ -272,9 +272,12 @@ export function startFileSystemWatching(
 
       metadataQueue.push(newItem);
     })
-    .on('unlink', (filePath: string) => {           // note: this happens even when file is renamed!
-      console.log(' !!! FILE DELETED, updating Angular:', filePath);
-      GLOBALS.angularApp.sender.send('single-file-deleted', inputSource, filePath);
+    .on('unlink', (partialFilePath: string) => {    // note: this happens even when file is renamed!
+      console.log(' !!! FILE DELETED, updating Angular:', partialFilePath);
+      GLOBALS.angularApp.sender.send('single-file-deleted', inputSource, partialFilePath);
+      // remove element from `alreadyInAngular`
+      const basePath: string = GLOBALS.selectedSourceFolders[inputSource].path;
+      alreadyInAngular.delete(path.join(basePath, partialFilePath));
       // note: there is no need to watch for `unlinkDir` since `unlink` fires for every file anyway!
     })
     .on('ready', () => {


### PR DESCRIPTION
Closes #575 
- by removing file from `alreadyInAngular` when a file is deleted fixes the bug 
- allows `1.mp4` -> `2.mp4` rename, followed by `2.mp4` -> `1.mp4` rename 🎉 (previously the app wouldn't find the new file until it was restarted / hub was closed & opened)
- fixed with https://github.com/whyboris/Video-Hub-App/commit/ce2a7c691c90c97de07a5039da4cff290f1988ce
- thank you @CrendKing for finding this bug 😁 🤝 😎 