### PR TITLE
Word cloud fix

### DIFF
--- a/src/app/common/filters.ts
+++ b/src/app/common/filters.ts
@@ -11,15 +11,15 @@ interface FilterObject {
 }
 
 export const FilterKeyNames: string[] = [
-  'folderUnion',
-  'folderIntersection',
-  'fileUnion',
-  'fileIntersection',
-  'exclude',
-  'tagUnion',
-  'tagIntersection',
-  'tagExclusion',
-  'videoNotes',
+  'folderUnion',        // [0]
+  'folderIntersection', // [1]
+  'fileUnion',          // [2]
+  'fileIntersection',   // [3]
+  'exclude',            // [4]
+  'tagUnion',           // [5]
+  'tagIntersection',    // [6]
+  'tagExclusion',       // [7]
+  'videoNotes',         // [8]
 ];
 
 export let Filters: FilterObject[] = [

--- a/src/app/components/home.component.html
+++ b/src/app/components/home.component.html
@@ -1082,7 +1082,7 @@
     *ngIf="settingsButtons['showFreq'].toggled"
     class="cloud-frequency"
   >
-    <ng-container *ngFor="let word of wordFreqArr; index as i">
+    <ng-container *ngFor="let word of wordFreqArr">
       <span
         [ngStyle]="{'font-size': word.height + 'px' }"
         (click)="handleFileWordClicked(word.word, $event)"

--- a/src/app/components/home.component.html
+++ b/src/app/components/home.component.html
@@ -1085,7 +1085,7 @@
     <ng-container *ngFor="let word of wordFreqArr">
       <span
         [ngStyle]="{'font-size': word.height + 'px' }"
-        (click)="handleFileWordClicked(word.word, $event)"
+        (click)="handleTagWordClicked(word.word, $event)"
       >
         {{ word.word }}
       </span>

--- a/src/app/components/home.component.ts
+++ b/src/app/components/home.component.ts
@@ -1145,6 +1145,15 @@ export class HomeComponent implements OnInit, AfterViewInit {
       return;
     }
 
+    if (  // if all tags disabled, perform a FILE search
+         !this.settingsButtons['manualTags'].toggled
+      && !this.settingsButtons['autoFileTags'].toggled
+      && !this.settingsButtons['autoFolderTags'].toggled
+    ) {
+      this.handleFileWordClicked(filter, event);
+      return;
+    }
+
     this.showSidebar();
     if (event && event.shiftKey) { // Shift click to exclude tag!
       if (!this.settingsButtons['tagExclusion'].toggled) {

--- a/src/app/components/home.component.ts
+++ b/src/app/components/home.component.ts
@@ -1133,10 +1133,9 @@ export class HomeComponent implements OnInit, AfterViewInit {
   }
 
   // -----------------------------------------------------------------------------------------------
-  // handle output from top.component
 
   /**
-   * Add filter to FILE search when word in file is clicked
+   * Add filter to tag search when word in word cloud or tag tray is clicked
    * @param filter - particular tag clicked
    */
   handleTagWordClicked(filter: string, event?): void {
@@ -1147,16 +1146,16 @@ export class HomeComponent implements OnInit, AfterViewInit {
     }
 
     this.showSidebar();
-    if (event && event.shiftKey) { // Shift click to exclude
+    if (event && event.shiftKey) { // Shift click to exclude tag!
       if (!this.settingsButtons['tagExclusion'].toggled) {
         this.settingsButtons['tagExclusion'].toggled = true;
       }
-      this.onEnterKey(filter, 7); // 7th item is the `tag` exlcude filter
+      this.onEnterKey(filter, 7); // 7th item is the `tagExclusion` filter in `FilterKeyNames`
     } else {
       if (!this.settingsButtons['tagIntersection'].toggled) {
         this.settingsButtons['tagIntersection'].toggled = true;
       }
-      this.onEnterKey(filter, 6); // 6th item is the `tag` filter
+      this.onEnterKey(filter, 6); // 6th item is the `tagIntersection` filter in `FilterKeyNames`
     }
   }
 
@@ -1166,16 +1165,16 @@ export class HomeComponent implements OnInit, AfterViewInit {
    */
   handleFileWordClicked(filter: string, event?): void {
     this.showSidebar();
-    if (event && event.shiftKey) {
+    if (event && event.shiftKey) { // Shift click to exclude tag!
       if (!this.settingsButtons['exclude'].toggled) {
         this.settingsButtons['exclude'].toggled = true;
       }
-      this.onEnterKey(filter, 4); // 3rd item is the `exclude` filter
+      this.onEnterKey(filter, 4); // 4th item is the `exclude` filter in `FilterKeyNames`
     } else {
       if (!this.settingsButtons['fileIntersection'].toggled) {
         this.settingsButtons['fileIntersection'].toggled = true;
       }
-      this.onEnterKey(filter, 3); // 3rd item is the `fileIntersection` filter
+      this.onEnterKey(filter, 3); // 3rd item is the `fileIntersection` filter in `FilterKeyNames`
     }
   }
 

--- a/src/app/components/search.scss
+++ b/src/app/components/search.scss
@@ -90,7 +90,9 @@
 .cloud-frequency {
   color: $gray-90;
   line-height: 26px;
-  padding: 20px;
+  max-height: 140px;
+  overflow: hidden;
+  padding: 20px 20px 0;
 
   span {
     cursor: pointer;

--- a/src/app/pipes/file-search.pipe.ts
+++ b/src/app/pipes/file-search.pipe.ts
@@ -32,13 +32,11 @@ export class FileSearchPipe implements PipeTransform {
     autoFileTags?: boolean,
     autoFolderTags?: boolean
   ): ImageElement[] {
-    // console.log('fileSearchPipe triggered');
-    // console.log(arrOfStrings);
 
     if (arrOfStrings.length === 0) {
       return finalArray;
     } else {
-      // console.log('file search pipe working');
+
       return finalArray.filter((item) => {
 
         // exact prefix match
@@ -49,16 +47,18 @@ export class FileSearchPipe implements PipeTransform {
         let matchFound = 0;
 
         arrOfStrings.forEach(element => {
-          // search through the FILE or FOLDER array !!!
+
           let searchString = '';
           if (searchType === 'folder') {
             searchString = item.partialPath;
+
           } else if (searchType === 'file') {
             searchString = item.fileName;
+
           } else if (searchType === 'notes') {
             searchString = item.notes || '';
+
           } else if (searchType === 'tag') {
-            searchString = '';
             if (manualTags && item.tags) {
               searchString += item.tags.join(' ');
             }
@@ -69,6 +69,7 @@ export class FileSearchPipe implements PipeTransform {
               searchString += ' ' + item.partialPath.replace(/(\/)/, ' ');
             }
           }
+
           if (searchString.toLowerCase().indexOf(element.toLowerCase()) !== -1) {
             matchFound++;
           }

--- a/src/app/pipes/word-frequency.pipe.ts
+++ b/src/app/pipes/word-frequency.pipe.ts
@@ -39,7 +39,9 @@ export class WordFrequencyPipe implements PipeTransform {
         if (showManualTags && element.tags) {
           this.wordFrequencyService.addString(element.tags.join(' '));
         }
-        if (showAutoFileTags) {
+        if (showAutoFileTags
+            || (!showAutoFileTags && !showManualTags && !showAutoFileTags)
+        ) {
           this.wordFrequencyService.addString(element.cleanName);
         }
         if (showAutoFolderTags) {
@@ -49,7 +51,7 @@ export class WordFrequencyPipe implements PipeTransform {
 
       // this.wordFrequencyService.cleanMap();
 
-      this.wordFrequencyService.computeFrequencyArray(finalArray.length, 100);
+      this.wordFrequencyService.computeFrequencyArray(finalArray.length, 165);
     }
 
     return finalArray;

--- a/src/app/pipes/word-frequency.service.ts
+++ b/src/app/pipes/word-frequency.service.ts
@@ -73,7 +73,7 @@ export class WordFrequencyService {
     let currLargestWord = '';
 
     this.wordMap.forEach((value, key) => {
-      if (value > currLargestFreq && value < total) {
+      if (value > currLargestFreq && value <= total) {
         currLargestFreq = value;
         currLargestWord = key;
       }
@@ -89,12 +89,12 @@ export class WordFrequencyService {
 
   /**
    * Computes the array `numberOfTags` objects long with most frequent words
-   * Creates `height` property, scaled between 8 and 22 proportionally
+   * Creates `height` property, scaled between 12 and 22 proportionally
    * calls `.next` on BehaviorSubject
    * @param total: total number of files displayed
    **/
   public computeFrequencyArray(total: number, numberOfTags: number): void {
-    const finalResult: WordFreqAndHeight[] = []; // array of objects
+    const finalResult: WordFreqAndHeight[] = [];
     for (let i = 0; i < numberOfTags; i++) {
       if (this.wordMap.size > 0) {
         finalResult[i] = this.getMostFrequent(total);
@@ -117,7 +117,6 @@ export class WordFrequencyService {
       });
     }
 
-    // console.log(finalResult);
     this.finalMapBehaviorSubject.next(finalResult);
   }
 


### PR DESCRIPTION
Clicking on a word in the word cloud will perform a `tag` search (not a file search).

This is because we can generate a word cloud from any combination of `tag`, `file`, or `folder` strings 🎉 

I've made it so that if a user has all three types disabled, the word cloud is generated from the filenames ✅ and when clicking on a word in _Word cloud_, the app performs a _filename_ search 👌 