### PR TITLE
fix number of screenshots for duration too long / too short

### DIFF
--- a/node/main-support.ts
+++ b/node/main-support.ts
@@ -536,6 +536,9 @@ export function upgradeToVersion3(finalObject: FinalObject): void {
     finalObject.version = 3;
     finalObject.images.forEach((element: ImageElement) => {
       element.inputSource = 0
+      element.screens = computeNumberOfScreenshots(finalObject.screenshotSettings, element.duration);
+      // update number of screens to account for too-many or too-few cases
+      // as they were not handlede prior to version 3 release
     });
   }
 }


### PR DESCRIPTION
When upgrading from version 2 to version 3 😎 

Should be a nice bonus for people who have extraction settings that caused too-many-screens (to fin in a JPG) to be extracted, or too-few (if the clip duration was too short) 😅 