### PR TITLE
Tag tray UI fixes

### DIFF
--- a/src/app/components/home.component.html
+++ b/src/app/components/home.component.html
@@ -1078,6 +1078,7 @@
 
     [appState]="appState"
     [batchTaggingMode]="batchTaggingMode"
+    [darkMode]="settingsButtons['darkMode'].toggled"
     [settingsButtons]="settingsButtons"
   ></app-tag-tray>
 

--- a/src/app/components/layout.scss
+++ b/src/app/components/layout.scss
@@ -282,12 +282,6 @@
   bottom: 170px;
 }
 
-.tag-tray-menu-left {
-  margin-right: 10px;
-  padding-left: 5px;
-  position: relative;
-}
-
 .bottom-tray-dark {
   background: black;
   border-top: 1px solid $gray-80;

--- a/src/app/components/tag-tray/tag-tray.component.html
+++ b/src/app/components/tag-tray/tag-tray.component.html
@@ -31,11 +31,17 @@
       <span class="manual-tag-tray-label">
         {{ 'TAGS.clickVideoToSelect' | translate }}
       </span>
-      <span class="manual-tag-tray-label" style="line-height: 24px">
-        {{ 'TAGS.clickTagToAdd' | translate }}
+
+      <span class="more-info">
+        i
       </span>
+
+      <div class="manual-tag-tray-label-info" style="line-height: 24px">
+        {{ 'TAGS.clickTagToAdd' | translate }}
+      </div>
+
       <button
-        class="wizard-button wizard-button-small"
+        class="wizard-button wizard-button-small button-select-all"
         [ngClass]="{ 'select-all-dark': settingsButtons['darkMode'].toggled }"
         (click)="selectAll.emit()"
       >

--- a/src/app/components/tag-tray/tag-tray.component.html
+++ b/src/app/components/tag-tray/tag-tray.component.html
@@ -28,7 +28,7 @@
 
   <ng-template #batchModeExplainer>
     <div class="tag-tray-menu-left">
-      <span class="manual-tag-tray-label">
+      <span class="manual-tag-tray-label" [ngStyle]="{ color: darkMode ? 'white' : 'black' }">
         {{ 'TAGS.clickVideoToSelect' | translate }}
       </span>
 

--- a/src/app/components/tag-tray/tag-tray.component.scss
+++ b/src/app/components/tag-tray/tag-tray.component.scss
@@ -8,6 +8,15 @@
     outline: none;
   }
 
+  .tag-tray-menu-left {
+    margin-right: 10px;
+    min-width: 166px;
+    padding: 12px 0 0 5px;
+    position: relative;
+    text-align: right;
+    width: 166px;
+  }
+
   .manual-tag-tray-label,
   .tag-sort-by-toggle,
   .show-frequency {
@@ -18,7 +27,37 @@
   }
 
   .manual-tag-tray-label {
+    display: inline;
     margin-top: 16px;
+  }
+
+  .more-info {
+    display: inline-block;
+    margin-left: 2px;
+  }
+
+  .manual-tag-tray-label-info {
+    background-color: #eeeeee;
+    border: 1px solid #888888;
+    border-radius: 5px;
+    font-size: 12px;
+    opacity: 0;
+    padding: 5px 10px;
+    pointer-events: none;
+    position: absolute;
+    text-align: left;
+    width: 200px;
+    z-index: 30;
+  }
+
+  .more-info:hover + .manual-tag-tray-label-info {
+    opacity: 1;
+  }
+
+  .button-select-all {
+    bottom: 42px;
+    left: 10px;
+    position: absolute;
   }
 
   .tag-sort-by-toggle,

--- a/src/app/components/tag-tray/tag-tray.component.ts
+++ b/src/app/components/tag-tray/tag-tray.component.ts
@@ -27,6 +27,7 @@ export class TagTrayComponent {
 
   @Input() appState: AppStateInterface;
   @Input() batchTaggingMode;
+  @Input() darkMode: boolean;
   @Input() settingsButtons: SettingsButtonsType;
 
   manualTagFilterString: string = '';


### PR DESCRIPTION
- batch tagging info now hidden, shown _on hover_
- "select all" button positioned correctly (independent of text length).

A user emailed me showing that the French translation's text was so long that it pushed the "select all" button out of view 😱