### PR TITLE
Resolution bucket and label bugfix

### DIFF
--- a/node/main-support.ts
+++ b/node/main-support.ts
@@ -64,7 +64,7 @@ function labelVideo(width: number, height: number): ResolutionMeta {
   } else if (width > 1920) {
     label = '1080+';
     bucket = 2.5;
-  } else if (width > 720) {
+  } else if (width > 1280) {
     label = '720+';
     bucket = 1.5;
   }


### PR DESCRIPTION
For 2 years VHA has been misclassifying videos as `720+` 😓 

Thank you to Trip for catching the bug! 😁 