### PR TITLE
Adding text-shadow to time/rez classes

### DIFF
--- a/src/app/components/views/time-and-rez.scss
+++ b/src/app/components/views/time-and-rez.scss
@@ -3,6 +3,15 @@
   color: rgba(255, 255, 255, 0.8);
   font-size: 10px;
   position: absolute;
+    text-shadow:
+    -1px  -1px  3px #000,
+    0px   -1px  3px #000,
+    1px   -1px  3px #000,
+    1px    0px  3px #000,
+    1px    1px  3px #000,
+    0px    1px  3px #000,
+    -1px   1px  3px #000,
+    -1px   0px  3px #000;
   z-index: 2;
 }
 


### PR DESCRIPTION
Makes the time and rez metadata display exceedingly more readable.