### PR TITLE
Add more macOS menu/shortcuts

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -119,9 +119,16 @@ function createWindow() {
         ]
       },
       {
+        label: "View",
+        submenu: [
+          { role: "togglefullscreen" },
+        ]
+      },
+      {
         label: "Window",
         role: 'windowMenu',
-      }]));
+      },
+    ]));
   }
 
   // Create the browser window.

--- a/main.ts
+++ b/main.ts
@@ -105,7 +105,8 @@ function createWindow() {
       {
         label: app.name,
         submenu: [
-          { role: 'quit' }
+          { role: 'quit' },
+          { role: 'hide' },
         ]
       },
       {
@@ -116,8 +117,11 @@ function createWindow() {
           { role: 'copy' },
           { role: 'paste' }
         ]
-      }
-    ]));
+      },
+      {
+        label: "Window",
+        role: 'windowMenu',
+      }]));
   }
 
   // Create the browser window.


### PR DESCRIPTION
Requested feature (#691)
Added a "Hide `app.name`" menu item and shortcut.
Added "Window" and "View" labels (submenus).
The `window` menu role comes with not only "Minimize", but also with zoom and tiling functionality.
But if, for example, you tile the window, it goes into sort of a Full Screen mode (but occupying half the screen). That's normal behavior in macOS, but there's no way to leave Full Screen mode without having the "Exit Full Screen" item/shortcut on the menu, so I added a "View" label with a "Enter/Exit Full Screen" item as well.