### PR TITLE
Linting fixes, npm scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /out-tsc
 /app-builds
 /remote
+/.idea
 
 *.js
 *.js.map

--- a/main.ts
+++ b/main.ts
@@ -7,7 +7,7 @@ import * as path from 'path';
 
 const fs = require('fs');
 const electron = require('electron');
-const { nativeTheme } = require('electron')
+const { nativeTheme } = require('electron');
 import { app, protocol, BrowserWindow, screen, dialog, systemPreferences, ipcMain } from 'electron';
 const windowStateKeeper = require('electron-window-state');
 

--- a/node/main-extract-async.ts
+++ b/node/main-extract-async.ts
@@ -138,7 +138,11 @@ function thumbQueueRunner(element: ImageElement, done): void {
       done();
     })
     .catch(() => {
-      sendCurrentProgress(thumbsDone, thumbsDone + thumbQueue.length() + 1, 'importingScreenshots');  // TODO check whether sending data off by 1
+      sendCurrentProgress( // TODO check whether sending data off by 1
+        thumbsDone,
+        thumbsDone + thumbQueue.length() + 1,
+        'importingScreenshots'
+      );
       thumbsDone++;
 
       extractAll(

--- a/node/main-ipc.ts
+++ b/node/main-ipc.ts
@@ -199,7 +199,7 @@ export function setUpIpcMessages(ipc, win, pathToAppData, systemMessages) {
   function notifyFileDeleted(event, fileToDelete, item) {
     fs.access(fileToDelete, fs.constants.F_OK, (err: any) => {
       if (err) {
-        console.log('FILE DELETED SUCCESS !!!')
+        console.log('FILE DELETED SUCCESS !!!');
         event.sender.send('file-deleted', item);
       }
     });
@@ -269,10 +269,10 @@ export function setUpIpcMessages(ipc, win, pathToAppData, systemMessages) {
   /**
    * Stop watching a particular folder
    */
-  ipc.on('start-watching-folder', (event, watchedFolderIndex: string, path: string, persistent: boolean) => {
+  ipc.on('start-watching-folder', (event, watchedFolderIndex: string, path2: string, persistent: boolean) => {
     // annoyingly it's not a number :     ^^^^^^^^^^^^^^^^^^ -- because object keys are strings :(
-    console.log('start watching:', watchedFolderIndex, path, persistent);
-    startWatcher(parseInt(watchedFolderIndex, 10), path, persistent);
+    console.log('start watching:', watchedFolderIndex, path2, persistent);
+    startWatcher(parseInt(watchedFolderIndex, 10), path2, persistent);
   });
 
   /**
@@ -293,7 +293,7 @@ export function setUpIpcMessages(ipc, win, pathToAppData, systemMessages) {
     const allHashes: Map<string, 1> = new Map();
 
     finalArray
-      .filter((element: ImageElement) => { return !element.deleted })
+      .filter((element: ImageElement) => { return !element.deleted; })
       .forEach((element: ImageElement) => {
         allHashes.set(element.hash, 1);
       });

--- a/node/main-support.ts
+++ b/node/main-support.ts
@@ -326,7 +326,8 @@ function getFileDuration(metadata): number {
  function getFps(metadata): number {
    if (metadata?.streams?.[0]?.r_frame_rate) {
      const fps = metadata.streams[0].r_frame_rate;
-     const evalFps = eval(fps.toString()); // `eval` because FPS is a fraction like `24000/1001`
+     const fpsParts = fps.split('/');
+     const evalFps = Number(fpsParts[0]) / Number(fpsParts[1]); // FPS is a fraction like `24000/1001`
      return Math.round(evalFps);
    } else {
      return 0;
@@ -384,10 +385,10 @@ function hashFileAsync(pathToFile: string, stats: Stats): Promise<string> {
     let data: Buffer;
 
     if (fileSize < sampleThreshold) {
-      data = fs.readFile(pathToFile, (err, data) => {
+      fs.readFile(pathToFile, (err, data2) => {
         if (err) { throw err; }
         // append the file size to the data
-        const buf = Buffer.concat([data, Buffer.from(fileSize.toString())]);
+        const buf = Buffer.concat([data2, Buffer.from(fileSize.toString())]);
         // make the magic happen!
         const hash = hasher('md5').update(buf.toString('hex')).digest('hex');
         resolve(hash);
@@ -395,10 +396,10 @@ function hashFileAsync(pathToFile: string, stats: Stats): Promise<string> {
     } else {
       data = Buffer.alloc(sampleSize * 3);
       fs.open(pathToFile, 'r', (err, fd) => {
-        fs.read(fd, data, 0, sampleSize, 0, (err, bytesRead, buffer) => { // read beginning of file
-          fs.read(fd, data, sampleSize, sampleSize, fileSize / 2, (err, bytesRead, buffer) => {
-            fs.read(fd, data, sampleSize * 2, sampleSize, fileSize - sampleSize, (err, bytesRead, buffer) => {
-              fs.close(fd, (err) => {
+        fs.read(fd, data, 0, sampleSize, 0, (err2, bytesRead, buffer) => { // read beginning of file
+          fs.read(fd, data, sampleSize, sampleSize, fileSize / 2, (err3, bytesRead2, buffer2) => {
+            fs.read(fd, data, sampleSize * 2, sampleSize, fileSize - sampleSize, (err4, bytesRead3, buffer3) => {
+              fs.close(fd, (err5) => {
                 // append the file size to the data
                 const buf = Buffer.concat([data, Buffer.from(fileSize.toString())]);
                 // make the magic happen!

--- a/node/server.ts
+++ b/node/server.ts
@@ -1,4 +1,4 @@
-import { GLOBALS } from "./main-globals";
+import { GLOBALS } from './main-globals';
 
 import * as path from 'path';
 
@@ -6,12 +6,12 @@ const express = require('express');
 // const bodyParser = require('body-parser'); ----------------------------- disabled
 const WebSocket = require('ws');
 
-import { ImageElement } from "../interfaces/final-object.interface";
+import { ImageElement } from '../interfaces/final-object.interface';
 
 const args = process.argv.slice(1);
 const serve: boolean = args.some(val => val === '--serve');
 
-import { RemoteSettings } from "../interfaces/settings-object.interface";
+import { RemoteSettings } from '../interfaces/settings-object.interface';
 
 // =================================================================================================
 
@@ -149,24 +149,24 @@ const socketMessageHandler = (message: string): void => {
   } catch {
     console.log('ERROR: message was not JSON encoded');
   }
-}
+};
 
 /**
  * Shut down the Express and WebSocket servers
  */
 function stopTheServers(): void {
-  if (serverRef && typeof serverRef.close === "function") {
+  if (serverRef && typeof serverRef.close === 'function') {
     serverRef.close();
     console.log('closed Express server');
   }
-  if (wss && typeof wss.close === "function") {
+  if (wss && typeof wss.close === 'function') {
     wss.close();
     console.log('closed Socket server');
   }
 }
 
 const { networkInterfaces, hostname } = require('os');
-const ip = require("ip");
+const ip = require('ip');
 
 /**
  * Log the user's IP

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "build": "npm run electron:serve-tsc && ng build --base-href ./",
     "build:prod": "npm run build -- -c production",
     "buildsize": "sh ./bin/buildSizeCheck.sh",
+    "check:lint": "tslint --project ./",
     "hasRemote": "sh ./bin/hasRemoteCheck.sh",
     "electron": "npm run hasRemote && npm run build:prod && electron-builder build && npm run buildsize",
     "electron:serve": "wait-on tcp:4200 && npm run electron:serve-tsc && npx electron . --serve",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "build:prod": "npm run build -- -c production",
     "buildsize": "sh ./bin/buildSizeCheck.sh",
     "check:lint": "tslint --project ./tsconfig.json && tslint --project ./tsconfig-serve.json && tslint --project ./tsconfig.worker.json",
+    "check:tsc": "tsc --project ./tsconfig.json --noEmit && tsc --project ./tsconfig-serve.json --noEmit && tsc --project ./tsconfig.worker.json --noEmit",
     "hasRemote": "sh ./bin/hasRemoteCheck.sh",
     "electron": "npm run hasRemote && npm run build:prod && electron-builder build && npm run buildsize",
     "electron:serve": "wait-on tcp:4200 && npm run electron:serve-tsc && npx electron . --serve",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "build": "npm run electron:serve-tsc && ng build --base-href ./",
     "build:prod": "npm run build -- -c production",
     "buildsize": "sh ./bin/buildSizeCheck.sh",
-    "check:lint": "tslint --project ./",
+    "check:lint": "tslint --project ./tsconfig.json && tslint --project ./tsconfig-serve.json && tslint --project ./tsconfig.worker.json",
     "hasRemote": "sh ./bin/hasRemoteCheck.sh",
     "electron": "npm run hasRemote && npm run build:prod && electron-builder build && npm run buildsize",
     "electron:serve": "wait-on tcp:4200 && npm run electron:serve-tsc && npx electron . --serve",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "build": "npm run electron:serve-tsc && ng build --base-href ./",
     "build:prod": "npm run build -- -c production",
     "buildsize": "sh ./bin/buildSizeCheck.sh",
+    "check": "npm run check:tsc && npm run check:lint",
     "check:lint": "tslint --project ./tsconfig.json && tslint --project ./tsconfig-serve.json && tslint --project ./tsconfig.worker.json",
     "check:tsc": "tsc --project ./tsconfig.json --noEmit && tsc --project ./tsconfig-serve.json --noEmit && tsc --project ./tsconfig.worker.json --noEmit",
     "hasRemote": "sh ./bin/hasRemoteCheck.sh",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
   ],
   "main": "main.js",
   "license": "MIT",
+  "engines": {
+    "node": ">=v14"
+  },
   "scripts": {
     "start": "npm-run-all -p electron:serve ng:serve",
     "build": "npm run electron:serve-tsc && ng build --base-href ./",

--- a/src/app/common/languages.ts
+++ b/src/app/common/languages.ts
@@ -1,4 +1,4 @@
-import { SupportedLanguage } from "./app-state";
+import { SupportedLanguage } from './app-state';
 
 // Languages
 const Arabic     = require('../../../i18n/ar.json');

--- a/src/app/common/settings-buttons.ts
+++ b/src/app/common/settings-buttons.ts
@@ -855,4 +855,4 @@ export const SettingsButtons: SettingsButtonsType = {
     title: 'BUTTONS.videoNotesHint',
     toggled: false
   }
-}
+};

--- a/src/app/components/button/button-style.pipe.ts
+++ b/src/app/components/button/button-style.pipe.ts
@@ -23,7 +23,7 @@ export class ButtonStylePipe implements PipeTransform {
 
       defaultSettingsButtonDark:        !flatIcons && darkMode,
       defaultSettingsButtonDarkToggled: !flatIcons && darkMode && toggled
-    }
+    };
 
   }
 

--- a/src/app/components/button/button.component.ts
+++ b/src/app/components/button/button.component.ts
@@ -1,6 +1,6 @@
-import { Component, EventEmitter, Input, Output } from "@angular/core";
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 
-import { SettingsButtonKey, SettingsButtonsType } from "../../common/settings-buttons";
+import { SettingsButtonKey, SettingsButtonsType } from '../../common/settings-buttons';
 
 @Component({
   selector: 'app-button',

--- a/src/app/components/home.component.ts
+++ b/src/app/components/home.component.ts
@@ -105,7 +105,7 @@ export class HomeComponent implements OnInit, AfterViewInit {
   @ViewChild('magicSearch', { static: false }) magicSearch: ElementRef;
   @ViewChild('searchRef',   { static: false }) searchRef:   ElementRef;
 
-  @ViewChild(SortOrderComponent) sortOrderRef:SortOrderComponent;
+  @ViewChild(SortOrderComponent) sortOrderRef: SortOrderComponent;
 
   @ViewChild(VirtualScrollerComponent, { static: false }) virtualScroller: VirtualScrollerComponent;
 
@@ -445,7 +445,7 @@ export class HomeComponent implements OnInit, AfterViewInit {
     this.electronService.ipcRenderer.on('file-not-found', (event) => {
       this.zone.run(() => {
         this.modalService.openSnackbar(this.translate.instant('SETTINGS.fileNotFound'));
-      })
+      });
     });
 
     // when `remote-control` requests to open video
@@ -459,7 +459,7 @@ export class HomeComponent implements OnInit, AfterViewInit {
         wifi: ip,
         host: hostname,
         port: port
-      }
+      };
 
       console.log(serverDetails);
       this.serverDetailsBehaviorSubject.next(serverDetails);
@@ -597,7 +597,7 @@ export class HomeComponent implements OnInit, AfterViewInit {
       let somethingDeleted: boolean = false;
 
       this.imageElementService.imageElements
-        .filter((element: ImageElement) => { return element.inputSource == sourceIndex })
+        .filter((element: ImageElement) => { return element.inputSource == sourceIndex; })
         // notice the loosey-goosey comparison! this is because number  ^^  string comparison happening here!
         .forEach((element: ImageElement) => {
           // console.log(element.fileName);
@@ -618,7 +618,7 @@ export class HomeComponent implements OnInit, AfterViewInit {
     // mark the element in `imageElements[]` as `deleted`
     this.electronService.ipcRenderer.on('single-file-deleted', (event, sourceIndex: number, partialPath: string) => {
       this.imageElementService.imageElements
-        .filter((element: ImageElement) => { return element.inputSource == sourceIndex })
+        .filter((element: ImageElement) => { return element.inputSource == sourceIndex; })
         // notice the loosey-goosey comparison! this is because number  ^^  string comparison happening here!
         .forEach((element: ImageElement) => {
           if (
@@ -806,7 +806,7 @@ export class HomeComponent implements OnInit, AfterViewInit {
       // important for when user renames a folder for example
       this.imageElementService.imageElements
         .filter((currentElements: ImageElement) => {
-          return currentElements.deleted
+          return currentElements.deleted;
         })
         .forEach((deletedElement: ImageElement) => {
           if (deletedElement.hash === element.hash) {
@@ -890,7 +890,7 @@ export class HomeComponent implements OnInit, AfterViewInit {
       this.resetFinalArrayRef();
     } else {
       this.newVideoImportTimeout = setTimeout(() => {
-        this.resetFinalArrayRef()
+        this.resetFinalArrayRef();
       }, 3000);
     }
   }

--- a/src/app/components/home.component.ts
+++ b/src/app/components/home.component.ts
@@ -597,6 +597,7 @@ export class HomeComponent implements OnInit, AfterViewInit {
       let somethingDeleted: boolean = false;
 
       this.imageElementService.imageElements
+        // tslint:disable-next-line:triple-equals
         .filter((element: ImageElement) => { return element.inputSource == sourceIndex; })
         // notice the loosey-goosey comparison! this is because number  ^^  string comparison happening here!
         .forEach((element: ImageElement) => {
@@ -618,6 +619,7 @@ export class HomeComponent implements OnInit, AfterViewInit {
     // mark the element in `imageElements[]` as `deleted`
     this.electronService.ipcRenderer.on('single-file-deleted', (event, sourceIndex: number, partialPath: string) => {
       this.imageElementService.imageElements
+        // tslint:disable-next-line:triple-equals
         .filter((element: ImageElement) => { return element.inputSource == sourceIndex; })
         // notice the loosey-goosey comparison! this is because number  ^^  string comparison happening here!
         .forEach((element: ImageElement) => {
@@ -910,6 +912,7 @@ export class HomeComponent implements OnInit, AfterViewInit {
    */
   deleteInputSourceFiles(sourceIndex: number): void {
     this.imageElementService.imageElements.forEach((element: ImageElement) => {
+      // tslint:disable-next-line:triple-equals
       if (element.inputSource == sourceIndex) { // TODO -- stop the loosey goosey `==` and figure out `string` vs `number`
         element.deleted = true;
         this.imageElementService.finalArrayNeedsSaving = true;

--- a/src/app/components/meta/meta.component.ts
+++ b/src/app/components/meta/meta.component.ts
@@ -36,7 +36,7 @@ export class MetaComponent implements OnInit, OnDestroy {
   @Input() showVideoNotes: boolean;
   @Input() star: StarRating;
 
-  @Input() renameResponse: Observable<RenameFileResponse>
+  @Input() renameResponse: Observable<RenameFileResponse>;
 
   starRatingHack: StarRating;
   yearHack: number;
@@ -214,7 +214,7 @@ export class MetaComponent implements OnInit, OnDestroy {
     event.target.blur();
     this.renamingWIP = this.video.cleanName;
     event.stopPropagation();
-    this.renameError = false
+    this.renameError = false;
   }
 
   /**

--- a/src/app/components/modal/welcome.component.ts
+++ b/src/app/components/modal/welcome.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
+  // tslint:disable-next-line:component-selector
   selector: 'welcome-component',
   templateUrl: './welcome.component.html',
   styleUrls: ['./welcome.component.scss'],

--- a/src/app/components/rename-file/rename-file.component.ts
+++ b/src/app/components/rename-file/rename-file.component.ts
@@ -25,7 +25,7 @@ export class RenameFileComponent implements OnInit, OnDestroy {
   @Input() macVersion: boolean;
   @Input() selectedSourceFolder: string;
 
-  @Input() renameResponse: Observable<RenameFileResponse>
+  @Input() renameResponse: Observable<RenameFileResponse>;
 
   renamingWIP: string;
   renamingExtension: string;

--- a/src/app/components/shortcuts/shortcuts.component.ts
+++ b/src/app/components/shortcuts/shortcuts.component.ts
@@ -55,7 +55,7 @@ export class ShortcutsComponent {
 
     // 'quit',           // w - hardcoded in template
     // 'quit',           // q - hardcoded in template
-  ]
+  ];
 
   constructor(
     public shortcutService: ShortcutsService

--- a/src/app/components/shortcuts/shortcuts.service.ts
+++ b/src/app/components/shortcuts/shortcuts.service.ts
@@ -87,7 +87,7 @@ export class ShortcutsService {
     ['toggleSettings', 'o'],
     // quit -> q
     // quit -> w
-  ])
+  ]);
 
   constructor() { }
 
@@ -99,7 +99,7 @@ export class ShortcutsService {
     this.actionToKeyMap.clear();
     this.keyToActionMap.clear();
 
-    for (let [key, value] of Object.entries(keyToAction)) {
+    for (const [key, value] of Object.entries(keyToAction)) {
       this.actionToKeyMap.set(value, <any>key);
       this.keyToActionMap.set(<any>key, value);
     }

--- a/src/app/components/statistics/statistics.component.ts
+++ b/src/app/components/statistics/statistics.component.ts
@@ -114,7 +114,7 @@ export class StatisticsComponent implements OnInit, OnDestroy {
       if (data) { // first emit from subscription is `undefined`
         this.handleOldFolderReconnected(data.source, data.path);
       }
-    }))
+    }));
 
     this.eventSubscriptionMap.set('numberOfScreenshotsDeleted', this.numberScreenshotsDeleted.subscribe((deleted: number) => {
       if (deleted !== undefined) { // first emit from subscription is `undefined`
@@ -155,10 +155,10 @@ export class StatisticsComponent implements OnInit, OnDestroy {
 
       this.numberOfScreensDeleted = numDeleted;
       this.showNumberDeleted = true;
-      this.cd.detectChanges()
+      this.cd.detectChanges();
       setTimeout(() => {
         this.showNumberDeleted = false;
-        this.cd.detectChanges()
+        this.cd.detectChanges();
       }, 3000);
 
     }, 1000); // make sure it doesn't appear instantly -- feels like an error if it happens to quickly :P

--- a/src/app/components/tags-auto/tags.worker.ts
+++ b/src/app/components/tags-auto/tags.worker.ts
@@ -13,7 +13,7 @@ function received(message: any): void {
     postMessage(getCleanTwoWordMap(message.data.potentialTwoWordMap, message.data.onlyFileNames));
 
   }
-};
+}
 
 /**
  * Create the `twoWordFreqMap` by using the `potentialTwoWordMap` word map

--- a/src/app/components/views/file-path.service.ts
+++ b/src/app/components/views/file-path.service.ts
@@ -15,7 +15,7 @@ export class FilePathService {
     ' ': '%20',
     '(': '%28',
     ')': '%29',
-  }
+  };
 
   constructor(
     public sourceFolderService: SourceFolderService,
@@ -36,7 +36,7 @@ export class FilePathService {
       subfolder,
       hash + (video ? '.mp4' : '.jpg')
     )).replace(/\\/g, '/')
-      .replace(/[ \(\)]/g, (match) => { return this.replaceMap[match] })
+      .replace(/[ \(\)]/g, (match) => { return this.replaceMap[match]; });
       //         ^^^^^ replace the ` ` (space) as well as parentheses `(` and `)` with URL encoding from the `replaceMap`
   }
 
@@ -46,7 +46,7 @@ export class FilePathService {
    */
   getFileNameWithoutExtension(fileName: string): string {
     return fileName.slice().substr(0, fileName.lastIndexOf('.'));
-  };
+  }
 
   /**
    * return extension without file name
@@ -54,7 +54,7 @@ export class FilePathService {
    */
   getFileNameExtension(fileName: string): string {
     return fileName.slice().split('.').pop();
-  };
+  }
 
   /**
    * Return full filesystem path to video file

--- a/src/app/pipes/duplicateFinder.pipe.ts
+++ b/src/app/pipes/duplicateFinder.pipe.ts
@@ -33,7 +33,7 @@ export class DuplicateFinderPipe implements PipeTransform {
       let feature: Feature = undefined;
       let comparison: Function = undefined;
 
-      switch(dupeType) {
+      switch (dupeType) {
         case 'length':
           // console.log('DUPLICATE by LENGTH');
           sortBy = 'timeDesc';

--- a/src/app/pipes/regex-search.pipe.ts
+++ b/src/app/pipes/regex-search.pipe.ts
@@ -34,7 +34,7 @@ export class RegexSearchPipe implements PipeTransform {
 
       return finalArray.filter(item => {
         return item.fileName.match(re);
-      })
+      });
 
     }
   }

--- a/src/app/pipes/sorting.pipe.ts
+++ b/src/app/pipes/sorting.pipe.ts
@@ -111,13 +111,13 @@ export class SortingPipe implements PipeTransform {
     }
 
     if (property === 'aspectRatio') {
-      var xAspectRatio = x.width / x.height;
-      var yAspectRatio = y.width / y.height;
+      let xAspectRatio = x.width / x.height;
+      let yAspectRatio = y.width / y.height;
 
       if (xAspectRatio < yAspectRatio) {
-        if (decreasing) { return 1 } else { return -1;}
+        if (decreasing) { return 1; } else { return -1; }
       } if (xAspectRatio > yAspectRatio) {
-        if (decreasing) { return -1 } else { return 1;}
+        if (decreasing) { return -1; } else { return 1; }
       } else {
         return 0;
       }
@@ -126,14 +126,14 @@ export class SortingPipe implements PipeTransform {
     if (property === 'folderSize') {
 
       // want non-folders to be considered "less than" a folder so give negative value by default.
-      var xDisplay = -Infinity;
-      var yDisplay = -Infinity;
+      let xDisplay = -Infinity;
+      let yDisplay = -Infinity;
 
-      if(x.cleanName === "*FOLDER*"){
+      if (x.cleanName === '*FOLDER*') {
         xDisplay = parseInt(x.fileSizeDisplay, 10);
       }
 
-      if(y.cleanName === "*FOLDER*"){
+      if (y.cleanName === '*FOLDER*') {
         yDisplay = parseInt(y.fileSizeDisplay, 10);
       }
 
@@ -306,7 +306,7 @@ export class SortingPipe implements PipeTransform {
       return galleryArray.slice().sort((x: ImageElement, y: ImageElement): any => {
         return this.sortFunctionLol(x, y, 'fps', false);
       });
-    }else {
+    } else {
       return galleryArray.slice().sort((x: ImageElement, y: ImageElement): any => {
         return this.sortFunctionLol(x, y, 'index', true);
       });

--- a/src/app/pipes/sorting.pipe.ts
+++ b/src/app/pipes/sorting.pipe.ts
@@ -111,8 +111,8 @@ export class SortingPipe implements PipeTransform {
     }
 
     if (property === 'aspectRatio') {
-      let xAspectRatio = x.width / x.height;
-      let yAspectRatio = y.width / y.height;
+      const xAspectRatio = x.width / x.height;
+      const yAspectRatio = y.width / y.height;
 
       if (xAspectRatio < yAspectRatio) {
         if (decreasing) { return 1; } else { return -1; }

--- a/src/app/pipes/times-played.pipe.ts
+++ b/src/app/pipes/times-played.pipe.ts
@@ -12,11 +12,11 @@ export class TimesPlayedPipe implements PipeTransform {
    */
   transform(timesPlayed: number): string {
     if (timesPlayed) {
-      const rounded = Math.floor(timesPlayed+1)
+      const rounded = Math.floor(timesPlayed + 1);
 
       console.log(rounded);
       if (!isFinite(rounded)) {
-        return "∞"
+        return '∞';
       }
 
       return rounded.toString(10);


### PR DESCRIPTION
- package.json: 
  - Add npm script `check:lint` to lint all files per each tsconfig
  - Add npm script `check:tsc` to type check all files per each tsconfig
  - Add npm script `check` to run both `check:tsc` and `check:lint`
  - Specify `engines`, NodeJS v14.
- Auto-fix many linting issues
- Manually fix some linting issues
  - Rename shadowed variables
  - Replace `eval()` when calculating frame rate, with string split & explicit division
- Disable linting for some warnings.
- `.gitignore:` Ignore `/.idea`, added by IntelliJ IDEA

I tried adding a new Workflow to execute `check`, but it failed to install `fsevents`. I don't know how to fix this using `npm`, I suggest replacing `npm` and `package-lock.json` with `yarn` and `yarn.lock`, which behaves better across different systems.

[Failing CI step](https://github.com/laurence-myers/Video-Hub-App/runs/3577886159?check_suite_focus=true#step:6:4)