### PR TITLE
updating text color of video year when in dark mode

### DIFF
--- a/src/app/components/meta/meta.component.html
+++ b/src/app/components/meta/meta.component.html
@@ -50,6 +50,7 @@
         placeholder="YYYY"
         type="number"
         tabindex="-1"
+        [ngStyle]="{color: darkMode ? '#DDDDDD' : '#000000'}"
       >
 
   </span>


### PR DESCRIPTION
Adding ngStyle directive to update the color of the 'year' text for a movie when in dark mode

<img width="480" alt="Screen Shot 2021-10-04 at 9 46 56 PM" src="https://user-images.githubusercontent.com/11615239/135948623-90301395-328e-4408-a866-1347ae137d02.png">

