### PR TITLE
fix: times played is now visible

### DIFF
--- a/src/app/components/meta/meta.component.html
+++ b/src/app/components/meta/meta.component.html
@@ -123,7 +123,7 @@
   </button>
 
   <!-- Times played -->
-  <span class="fileSize times-played" *ngIf="video.timesPlayed">
+  <span class="fileSize times-played" [ngStyle]="{color: darkMode ? '#DDDDDD' : '#000000'}"  *ngIf="video.timesPlayed">
     {{ 'TAGS.timesPlayed' | translate }}: {{ video.timesPlayed }}
   </span>
 


### PR DESCRIPTION
Description
comment: # The text times played wasn't visible in the dark mode because the color of the text was in black so with this pull request now it is visible for both modes light mode and dark mode.

Fixes # Make Times Played visible in dark mode #719

Type of change
Bug fixing

Screenshots

Before
![image](https://user-images.githubusercontent.com/43447257/148256065-b9a7554a-2559-4fd8-8777-26a70922c909.png)


After
![image](https://user-images.githubusercontent.com/43447257/148255916-b8a69ef0-d44e-457f-ab04-412e076d5019.png)


