### PR TITLE
Add optional password to hub

### DIFF
--- a/interfaces/final-object.interface.ts
+++ b/interfaces/final-object.interface.ts
@@ -24,6 +24,7 @@ export interface FinalObject {
   removeTags: string[];          // tags to remove
   screenshotSettings: ScreenshotSettings;
   version: number;               // version of this vha file
+  password?: string; // Optional password field
 }
 
 export interface ImageElement {
@@ -102,4 +103,21 @@ export interface ScreenshotSettings {
   fixed: boolean;
   height: AllowedScreenshotHeight;
   n: number;
+}
+
+//Setting the password
+import bcrypt from 'bcrypt';
+
+const saltRounds = 10;
+
+async function setPassword(finalObject: FinalObject, plainPassword: string) {
+  const hashedPassword = await bcrypt.hash(plainPassword, saltRounds);
+  finalObject.password = hashedPassword; // Store the hashed password
+}
+
+// Verifying the password
+async function verifyPassword(finalObject: FinalObject, inputPassword: string) {
+  if (!finalObject.password) return false; // No password set
+  const match = await bcrypt.compare(inputPassword, finalObject.password);
+  return match; // Returns true if the password matches
 }


### PR DESCRIPTION
This update introduces a password feature for hubs within the application. When a hub with a password is opened, a modal prompts the user to enter the password. If the entered password is incorrect, the input is cleared, and no interactions with the app are allowed until the correct password is provided.

To enhance security, passwords will be hashed before storage using bcrypt, making it more challenging for unauthorized users to access sensitive information. This implementation addresses user requests for increased privacy while acknowledging that the password is stored in an easily accessible format within the .vha2 files

![Screenshot 2024-10-16 200244](https://github.com/user-attachments/assets/583a7b21-c6e2-4316-a0cb-56400bcf089c)
