### PR TITLE
Add Issue and Pull Request templates in .github folder

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,37 @@
+---
+name: Bug report
+about: Report a bug to help us improve the project
+title: "[BUG] "
+labels: bug
+assignees: ""
+---
+
+## Description
+
+A clear and concise description of what the bug is.
+
+**Steps to Reproduce:**
+
+1. Step 1
+2. Step 2
+3. Step 3
+
+**Expected behavior:**
+What did you expect to happen?
+
+**Actual behavior:**
+What happened instead?
+
+## Screenshots
+
+If applicable, add screenshots to help explain the problem.
+
+## Environment (please complete the following information):\*\*
+
+- OS: [e.g. MacOS, Windows]
+- Browser [e.g. Chrome, Firefox]
+- Version of the application
+
+## Additional context
+
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,29 @@
+---
+name: Feature request
+about: Suggest a new feature for the project
+title: "[FEATURE] "
+labels: enhancement
+assignees: ""
+---
+
+## Feature Description
+
+Describe the feature or enhancement you'd like to see implemented in the project.
+
+**What problem does this solve?**
+Explain why this feature is important, what problem it solves, and how it benefits the users.
+
+## Proposed Solution
+
+Describe how the feature should work, providing examples if possible.
+
+**Is this part of a larger feature request or related to other issues?**
+If yes, provide links to other issues or features.
+
+## Alternatives Considered
+
+Have you considered any alternative solutions? Please list them here.
+
+## Additional Context
+
+Include any screenshots, mockups, or other relevant context.

--- a/.github/ISSUE_TEMPLATE/fix.md
+++ b/.github/ISSUE_TEMPLATE/fix.md
@@ -1,0 +1,44 @@
+---
+name: Fix
+about: Suggest a fix for an existing issue or bug in the project
+title: "[FIX] "
+labels: fix
+assignees: ""
+---
+
+## Issue
+
+Provide a brief description of the issue you're fixing:
+
+**Description:**
+A detailed description of the issue you are fixing. Include error messages, logs, and any steps to reproduce.
+
+**Steps to Reproduce:**
+
+1. Step 1
+2. Step 2
+3. Step 3
+
+**Observed Behavior:**
+What is the current behavior?
+
+**Expected Behavior:**
+What is the expected behavior after applying the fix?
+
+## Proposed Fix
+
+Describe the fix and proposed changes in detail:
+
+**Proposed Changes in code (if applicable):**
+
+- changes 1
+- changes 2
+
+## Steps to Test
+
+1. How to replicate the problem?
+2. How to test that the fix works?
+
+## Additional Context
+
+Any screenshots, logs, or other context to help explain the issue or fix.

--- a/.github/ISSUE_TEMPLATE/other.md
+++ b/.github/ISSUE_TEMPLATE/other.md
@@ -1,0 +1,29 @@
+---
+name: Feature request
+about: Suggest a new feature for the project
+title: "[FEATURE] "
+labels: enhancement
+assignees: ""
+---
+
+## Feature Description
+
+Describe the feature or enhancement you'd like to see implemented in the project.
+
+**What problem does this solve?**
+Explain why this feature is important, what problem it solves, and how it benefits the users.
+
+## Proposed Solution
+
+Describe how the feature should work, providing examples if possible.
+
+**Is this part of a larger feature request or related to other issues?**
+If yes, provide links to other issues or features.
+
+## Alternatives Considered
+
+Have you considered any alternative solutions? Please list them here.
+
+## Additional Context
+
+Include any screenshots, mockups, or other relevant context.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,40 @@
+## Description
+
+Please include a summary of the change and which issue is fixed. List any dependencies that are required for this change.
+
+Fixes #(issue) <!-- Example: Fixes #12 -->
+
+## Type of change
+
+Please delete options that are not relevant:
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+
+## How Has This Been Tested?
+
+Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Include details of your testing configuration:
+
+- [ ] Test A
+- [ ] Test B
+
+## Checklist:
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] Any dependent changes have been merged and published in downstream modules
+
+## Screenshots (if applicable):
+
+Add screenshots to demonstrate the change (UI changes, errors, etc.).
+
+## Additional context
+
+Add any other relevant context about the pull request here (e.g., links to related discussions, issues, or other PRs).


### PR DESCRIPTION
## Description

This PR adds Issue and Pull Request templates to the `.github` folder to improve the contribution workflow for the project. The templates cover bug reports, feature requests, fixes, and general inquiries, as well as a standardized format for all pull requests.

Fixes #866 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

These changes have been tested by creating local issues and pull requests in a test repository, ensuring that the templates are automatically loaded during the issue/PR creation process.

- [x] Verified that all templates load correctly when creating a new issue.
- [x] Verified that the Pull Request template is applied automatically when opening a new PR.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Additional Context

These templates will ensure consistency and provide clear guidelines for contributors when submitting issues and pull requests, streamlining the review process and improving project organization.
