### PR TITLE
feat: added feature to select color for manual tags for issue #887

### DIFF
--- a/interfaces/final-object.interface.ts
+++ b/interfaces/final-object.interface.ts
@@ -23,6 +23,7 @@ export interface FinalObject {
   numOfFolders: number;          // number of folders - is always re-counted when app starts
   removeTags: string[];          // tags to remove
   screenshotSettings: ScreenshotSettings;
+  tagColors?: Record<string, string>; // lookup table for tag name to color mapping
   version: number;               // version of this vha file
 }
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -62,6 +62,7 @@ import { SortOrderComponent } from './components/sort-order/sort-order.component
 import { StarFilterComponent } from './components/star-filter/star-filter.component';
 import { StatisticsComponent } from './components/statistics/statistics.component';
 import { SvgDefinitionsComponent } from './components/icon/svg-definitions.component';
+import { TagColorPickerComponent } from './components/tag-color-picker/tag-color-picker.component';
 import { TagsComponent } from './components/tags-auto/tags.component';
 import { TagTrayComponent } from './components/tag-tray/tag-tray.component';
 import { ThumbnailComponent } from './components/views/thumbnail/thumbnail.component';
@@ -168,6 +169,7 @@ import { YearPipe } from './pipes/year.pipe';
     StarFilterPipe,
     StatisticsComponent,
     SvgDefinitionsComponent,
+    TagColorPickerComponent,
     TagFilterPipe,
     TagFrequencyPipe,
     TagMatchPipe,

--- a/src/app/components/home.component.html
+++ b/src/app/components/home.component.html
@@ -1247,3 +1247,14 @@
   [wizard]="wizard"
 >
 </app-wizard>
+
+<!-- TAG COLOR PICKER -->
+<app-tag-color-picker
+  *ngIf="showTagColorPicker"
+  [position]="tagColorPickerPosition"
+  [currentColor]="currentTagColor"
+  [darkMode]="settingsButtons['darkMode'].toggled"
+  (colorSelected)="onTagColorSelected($event)"
+  (close)="onTagColorPickerClose()"
+>
+</app-tag-color-picker>

--- a/src/app/components/home.component.ts
+++ b/src/app/components/home.component.ts
@@ -145,6 +145,13 @@ export class HomeComponent implements OnInit, AfterViewInit {
   flickerReduceOverlay = true;
   isFirstRunEver = false;
 
+  // Tag color picker state
+  showTagColorPicker = false;
+  tagColorPickerPosition = { x: 0, y: 0 };
+  currentTagColor = '';
+  currentTagName = '';
+  tagColorPickerSubscription: any;
+
   // ========================================================================
   // Import / extraction progress
   // ------------------------------------------------------------------------
@@ -389,6 +396,15 @@ export class HomeComponent implements OnInit, AfterViewInit {
     this.changeLanguage('en');
 
     // this.modalService.openWelcomeMessage(); // WIP
+
+    // Subscribe to tag color picker events
+    this.tagColorPickerSubscription = this.manualTagsService.showColorPickerSubject.subscribe((data) => {
+      this.currentTagName = data.tagName;
+      this.currentTagColor = data.currentColor;
+      this.tagColorPickerPosition = data.position;
+      this.showTagColorPicker = true;
+      this.cd.detectChanges();
+    });
 
     setTimeout(() => {
       this.wordFrequencyService.finalMapBehaviorSubject.subscribe((value: WordFreqAndHeight[]) => {
@@ -723,6 +739,7 @@ export class HomeComponent implements OnInit, AfterViewInit {
       this.manualTagsService.removeAllTags();
       this.setTags(finalObject.addTags, finalObject.removeTags);
       this.manualTagsService.populateManualTagsService(finalObject.images);
+      this.manualTagsService.loadTagColors(finalObject.tagColors);
 
       this.imageElementService.imageElements = this.demo ? finalObject.images.slice(0, 50) : finalObject.images;
 
@@ -1070,6 +1087,7 @@ export class HomeComponent implements OnInit, AfterViewInit {
         numOfFolders: this.appState.numOfFolders,
         removeTags: this.autoTagsSaveService.getRemoveTags(),
         screenshotSettings: this.currentScreenshotSettings,
+        tagColors: this.manualTagsService.getTagColors(),
         version: 3,
       };
       return propsToReturn;
@@ -2410,6 +2428,23 @@ export class HomeComponent implements OnInit, AfterViewInit {
     console.log('stopping server');
     this.electronService.ipcRenderer.send('stop-server');
     this.serverDetailsBehaviorSubject.next(undefined);
+  }
+
+  /**
+   * Handle tag color selection from color picker
+   */
+  onTagColorSelected(color: string): void {
+    this.manualTagsService.setTagColor(this.currentTagName, color);
+    this.showTagColorPicker = false;
+    // setTagColor will trigger tagColorUpdatedSubject which updates all views
+  }
+
+  /**
+   * Close tag color picker
+   */
+  onTagColorPickerClose(): void {
+    this.showTagColorPicker = false;
+    this.cd.detectChanges();
   }
 
 }

--- a/src/app/components/meta/meta.component.html
+++ b/src/app/components/meta/meta.component.html
@@ -144,8 +144,10 @@
                                   : tagViewUpdateHack)
                     | autoTagSortPipe : sortAutoTags"
     [darkMode]="darkMode"
+    [enableColorPicker]="true"
     (tagClicked)="filterThisTag($event)"
     (removeTagEmit)="removeThisTag($event)"
+    (tagRightClick)="onTagRightClick($event)"
     class="view-tags-holder"
     [ngStyle]="{ 'min-height': imgHeight - 128 + 'px' }"
   ></app-view-tags-component>

--- a/src/app/components/meta/meta.component.scss
+++ b/src/app/components/meta/meta.component.scss
@@ -8,7 +8,7 @@
   box-sizing: border-box;
   display: inline-block;
   height: 190px;
-  overflow: hidden; // will hide tags that don't fit in 2 lines
+  overflow: visible; // changed from hidden to allow color picker to show
   padding: 0 0 0 20px;
   vertical-align: top;
 }
@@ -108,7 +108,7 @@
   box-sizing: border-box;
   display: block;
   height: 60px;
-  overflow-y: auto;
+  overflow-y: visible; // changed from auto to allow color picker to show
   padding-bottom: 2px;
 }
 

--- a/src/app/components/meta/meta.component.ts
+++ b/src/app/components/meta/meta.component.ts
@@ -9,11 +9,12 @@ import { ElectronService } from '../../providers/electron.service';
 import { FilePathService } from '../views/file-path.service';
 import { ImageElementService } from './../../services/image-element.service';
 import { ManualTagsService } from '../tags-manual/manual-tags.service';
+import type { ColorPickerPosition } from '../tag-color-picker/tag-color-picker.component';
 
 import type { StarRating, ImageElement } from '../../../../interfaces/final-object.interface';
 import type { TagEmit, RenameFileResponse } from '../../../../interfaces/shared-interfaces';
 
-import {SettingsButtons } from '../../common/settings-buttons';
+import { SettingsButtons } from '../../common/settings-buttons';
 
 
 @Component({
@@ -52,8 +53,11 @@ export class MetaComponent implements OnInit, OnDestroy {
   renameError = false;
 
   responseSubscription: Subscription;
+  tagColorSubscription: Subscription;
 
   sortAutoTags = SettingsButtons['sortAutoTags'].toggled;
+
+  selectedTagForColor: string = '';
 
   constructor(
     private cd: ChangeDetectorRef,
@@ -87,6 +91,12 @@ export class MetaComponent implements OnInit, OnDestroy {
       }
     });
 
+    // Subscribe to tag color updates
+    this.tagColorSubscription = this.manualTagsService.tagColorUpdatedSubject.subscribe(() => {
+      this.tagViewUpdateHack = !this.tagViewUpdateHack;
+      this.cd.detectChanges();
+    });
+
   }
 
   addThisTag(tag: string) {
@@ -117,6 +127,24 @@ export class MetaComponent implements OnInit, OnDestroy {
       type: 'remove'
     });
     this.tagViewUpdateHack = !this.tagViewUpdateHack;
+  }
+
+  /**
+   * Handle tag right-click event - show color picker via service
+   * @param event - Object containing tag and mouse event
+   */
+  onTagRightClick(event: { tag: any, event: MouseEvent }): void {
+    this.selectedTagForColor = event.tag.name;
+
+    // Emit event to show color picker at home component level
+    this.manualTagsService.showColorPickerSubject.next({
+      tagName: event.tag.name,
+      currentColor: event.tag.colour || '',
+      position: {
+        x: event.event.clientX,
+        y: event.event.clientY
+      }
+    });
   }
 
   setStarRating(rating: StarRating): void {
@@ -251,5 +279,8 @@ export class MetaComponent implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.responseSubscription.unsubscribe();
+    if (this.tagColorSubscription) {
+      this.tagColorSubscription.unsubscribe();
+    }
   }
 }

--- a/src/app/components/tag-color-picker/tag-color-picker.component.html
+++ b/src/app/components/tag-color-picker/tag-color-picker.component.html
@@ -1,0 +1,36 @@
+<div class="color-picker-overlay" (click)="onClose()"></div>
+
+<div
+  class="color-picker-container"
+  [ngClass]="{ 'dark-mode': darkMode }"
+  [style.left.px]="position.x"
+  [style.top.px]="position.y"
+  (click)="$event.stopPropagation()"
+>
+  <div class="color-picker-header">
+    <span>Select Tag Color</span>
+    <button class="close-btn" (click)="onClose()">×</button>
+  </div>
+
+  <div class="color-grid">
+    <div
+      *ngFor="let color of colors"
+      class="color-swatch"
+      [style.background-color]="color"
+      [class.selected]="currentColor === color"
+      (click)="selectColor(color)"
+      [title]="color"
+    >
+      <span *ngIf="currentColor === color" class="checkmark">✓</span>
+    </div>
+  </div>
+
+  <div class="color-actions">
+    <button
+      class="default-btn"
+      (click)="clearColor()"
+    >
+      Reset to Default
+    </button>
+  </div>
+</div>

--- a/src/app/components/tag-color-picker/tag-color-picker.component.scss
+++ b/src/app/components/tag-color-picker/tag-color-picker.component.scss
@@ -1,0 +1,147 @@
+@import "../variables";
+
+.color-picker-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background: rgba(0, 0, 0, 0.3);
+  z-index: 100000;
+  pointer-events: auto;
+}
+
+.color-picker-container {
+  position: fixed;
+  background: white;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  padding: 16px;
+  min-width: 240px;
+  z-index: 100001;
+  pointer-events: auto;
+
+  &.dark-mode {
+    background: #2a2a2a;
+    border-color: #555;
+    color: #e0e0e0;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+  }
+}
+
+.color-picker-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+  font-weight: 600;
+  font-size: 14px;
+
+  .close-btn {
+    background: none;
+    border: none;
+    font-size: 24px;
+    cursor: pointer;
+    color: #666;
+    padding: 0;
+    width: 24px;
+    height: 24px;
+    line-height: 24px;
+
+    &:hover {
+      color: #000;
+    }
+  }
+
+  .dark-mode & .close-btn {
+    color: #aaa;
+
+    &:hover {
+      color: #fff;
+    }
+  }
+}
+
+.color-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.color-swatch {
+  width: 60px;
+  height: 60px;
+  border-radius: 6px;
+  cursor: pointer;
+  border: 2px solid transparent;
+  transition: all 0.2s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+
+  &:hover {
+    border-color: rgba(0, 0, 0, 0.3);
+    transform: scale(1.05);
+  }
+
+  &.selected {
+    border-color: #000;
+    box-shadow: 0 0 0 2px white, 0 0 0 4px #000;
+  }
+
+  .dark-mode & {
+    &:hover {
+      border-color: rgba(255, 255, 255, 0.3);
+    }
+
+    &.selected {
+      border-color: #fff;
+      box-shadow: 0 0 0 2px #2a2a2a, 0 0 0 4px #fff;
+    }
+  }
+
+  .checkmark {
+    font-size: 24px;
+    font-weight: bold;
+    color: white;
+    text-shadow: 0 0 3px rgba(0, 0, 0, 0.5);
+  }
+}
+
+.color-actions {
+  display: flex;
+  justify-content: center;
+  padding-top: 8px;
+  border-top: 1px solid #e0e0e0;
+
+  .dark-mode & {
+    border-top-color: #444;
+  }
+}
+
+.default-btn {
+  background: #f5f5f5;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  padding: 8px 16px;
+  cursor: pointer;
+  font-size: 13px;
+  transition: all 0.2s ease;
+
+  &:hover {
+    background: #e0e0e0;
+  }
+
+  .dark-mode & {
+    background: #3a3a3a;
+    border-color: #555;
+    color: #e0e0e0;
+
+    &:hover {
+      background: #4a4a4a;
+    }
+  }
+}

--- a/src/app/components/tag-color-picker/tag-color-picker.component.ts
+++ b/src/app/components/tag-color-picker/tag-color-picker.component.ts
@@ -1,0 +1,72 @@
+import { Component, EventEmitter, Input, Output, OnInit } from '@angular/core';
+
+export interface ColorPickerPosition {
+  x: number;
+  y: number;
+}
+
+@Component({
+  selector: 'app-tag-color-picker',
+  templateUrl: './tag-color-picker.component.html',
+  styleUrls: ['./tag-color-picker.component.scss']
+})
+export class TagColorPickerComponent implements OnInit {
+
+  @Input() position: ColorPickerPosition;
+  @Input() currentColor: string;
+  @Input() darkMode: boolean;
+
+  @Output() colorSelected = new EventEmitter<string>();
+  @Output() close = new EventEmitter<void>();
+
+  // 3x3 grid of distinct colors plus default option
+  colors: string[] = [
+    '#FF6B6B', // Red
+    '#4ECDC4', // Teal
+    '#45B7D1', // Light Blue
+    '#FFA07A', // Light Salmon
+    '#98D8C8', // Mint
+    '#F7DC6F', // Yellow
+    '#BB8FCE', // Purple
+    '#85C1E2', // Sky Blue
+    '#F8B88B', // Peach
+  ];
+
+  defaultColor = '#2196F3'; // Default tag color
+
+  constructor() { }
+
+  ngOnInit() {
+    // Adjust position to keep picker on screen
+    const pickerWidth = 240;
+    const pickerHeight = 300;
+
+    if (this.position) {
+      // Keep within horizontal bounds
+      if (this.position.x + pickerWidth > window.innerWidth) {
+        this.position.x = window.innerWidth - pickerWidth - 20;
+      }
+
+      // Keep within vertical bounds
+      if (this.position.y + pickerHeight > window.innerHeight) {
+        this.position.y = window.innerHeight - pickerHeight - 20;
+      }
+
+      // Ensure minimum position
+      if (this.position.x < 10) this.position.x = 10;
+      if (this.position.y < 10) this.position.y = 10;
+    }
+  }
+
+  selectColor(color: string): void {
+    this.colorSelected.emit(color);
+  }
+
+  clearColor(): void {
+    this.colorSelected.emit(null);
+  }
+
+  onClose(): void {
+    this.close.emit();
+  }
+}

--- a/src/app/components/tag-tray/tag-tray.component.html
+++ b/src/app/components/tag-tray/tag-tray.component.html
@@ -66,9 +66,12 @@
     class="all-the-tags"
     [draggable]="true"
     [displayFrequency]="manualTagShowFrequency"
+    [enableColorPicker]="true"
+    [darkMode]="darkMode"
     [tags]="manualTagsService.tagsList | manualTagSortPipe : manualTagFilterString
                                                            : appState.sortTagsByFrequency
                                                            : manualTagsService.pipeToggleHack"
     (tagClicked)="handleTagWordClicked.emit($event)"
+    (tagRightClick)="onTagRightClick($event)"
   ></app-view-tags-component>
 </div>

--- a/src/app/components/tag-tray/tag-tray.component.ts
+++ b/src/app/components/tag-tray/tag-tray.component.ts
@@ -37,4 +37,20 @@ export class TagTrayComponent {
     public manualTagsService: ManualTagsService,
   ) { }
 
+  /**
+   * Handle tag right-click event - show color picker via service
+   * @param event - Object containing tag and mouse event
+   */
+  onTagRightClick(event: { tag: any, event: MouseEvent }): void {
+    // Emit event to show color picker at home component level
+    this.manualTagsService.showColorPickerSubject.next({
+      tagName: event.tag.name,
+      currentColor: event.tag.colour || '',
+      position: {
+        x: event.event.clientX,
+        y: event.event.clientY
+      }
+    });
+  }
+
 }

--- a/src/app/components/tags-auto/tag-display.pipe.ts
+++ b/src/app/components/tags-auto/tag-display.pipe.ts
@@ -2,6 +2,7 @@ import type { PipeTransform } from '@angular/core';
 import { Pipe } from '@angular/core';
 
 import { autoFileTagsRegex } from './autotags.service';
+import { ManualTagsService } from '../tags-manual/manual-tags.service';
 
 import { Colors } from '../../common/colors';
 import type { ImageElement } from '../../../../interfaces/final-object.interface';
@@ -11,6 +12,8 @@ import type { Tag } from '../../../../interfaces/shared-interfaces';
   name: 'tagDisplayPipe'
 })
 export class TagsDisplayPipe implements PipeTransform {
+
+  constructor(private manualTagsService: ManualTagsService) { }
 
   transform(
     video: ImageElement,
@@ -27,7 +30,7 @@ export class TagsDisplayPipe implements PipeTransform {
         video.tags.sort().forEach(tag => {
           tags.push({
             name: tag,
-            colour: Colors.manualTags,
+            colour: this.manualTagsService.getTagColor(tag) || Colors.manualTags,
             removable: true
           });
         });

--- a/src/app/components/tags-manual/manual-tags.service.ts
+++ b/src/app/components/tags-manual/manual-tags.service.ts
@@ -1,13 +1,21 @@
 import { Injectable } from '@angular/core';
+import { Subject } from 'rxjs';
 
 import type { ImageElement } from '../../../../interfaces/final-object.interface';
+import type { ColorPickerPosition } from '../tag-color-picker/tag-color-picker.component';
 
 @Injectable()
 export class ManualTagsService {
 
   tagsMap: Map<string, number> = new Map(); // map tag name to its frequency
   tagsList: string[] = [];
+  tagColors: Record<string, string> = {}; // map tag name to its color
   pipeToggleHack = false;
+
+  // Color picker state - shared across all components
+  showColorPickerSubject = new Subject<{ tagName: string, currentColor: string, position: ColorPickerPosition }>();
+  hideColorPickerSubject = new Subject<void>();
+  tagColorUpdatedSubject = new Subject<void>(); // Notify when tag color changes
 
   constructor() { }
 
@@ -84,6 +92,46 @@ export class ManualTagsService {
 
   forceTagSortPipeUpdate(): void {
     this.pipeToggleHack = !this.pipeToggleHack;
+  }
+
+  /**
+   * Set the color for a tag
+   * @param tagName - name of the tag
+   * @param color - color hex code or null to remove color
+   */
+  setTagColor(tagName: string, color: string | null): void {
+    if (color === null || color === undefined) {
+      delete this.tagColors[tagName];
+    } else {
+      this.tagColors[tagName] = color;
+    }
+    // Notify all components that tag colors have been updated
+    this.tagColorUpdatedSubject.next();
+  }
+
+  /**
+   * Get the color for a tag
+   * @param tagName - name of the tag
+   * @returns color hex code or undefined if no color set
+   */
+  getTagColor(tagName: string): string | undefined {
+    return this.tagColors[tagName];
+  }
+
+  /**
+   * Load tag colors from saved data
+   * @param tagColors - Record of tag name to color mapping
+   */
+  loadTagColors(tagColors: Record<string, string> | undefined): void {
+    this.tagColors = tagColors || {};
+  }
+
+  /**
+   * Get all tag colors for saving
+   * @returns Record of tag name to color mapping
+   */
+  getTagColors(): Record<string, string> {
+    return this.tagColors;
   }
 
 }

--- a/src/app/components/tags-manual/view-tags.component.html
+++ b/src/app/components/tags-manual/view-tags.component.html
@@ -12,8 +12,12 @@
   <span
     class="search-or-tag-general tag"
     [ngClass]="{ 'tag-draggable': draggable }"
-    [ngStyle]="{ background: tag.colour }"
+    [ngStyle]="{
+      background: tag.colour,
+      color: tag.colour ? getContrastColor(tag.colour) : undefined
+    }"
     (click)="tagClick(tag, $event)"
+    (contextmenu)="onTagRightClick($event, tag)"
     [draggable]='draggable'
     (dragstart)="dragStart($event)"
   >

--- a/src/app/components/tags-manual/view-tags.component.ts
+++ b/src/app/components/tags-manual/view-tags.component.ts
@@ -4,6 +4,7 @@ import { Component, Input, Output, EventEmitter, ViewChild } from '@angular/core
 import { ManualTagsService } from './manual-tags.service';
 
 import type { Tag, TagEmit } from '../../../../interfaces/shared-interfaces';
+import type { ColorPickerPosition } from '../tag-color-picker/tag-color-picker.component';
 
 @Component({
   selector: 'app-view-tags-component',
@@ -18,7 +19,9 @@ export class ViewTagsComponent {
 
   @Input()
   set tags(tags: Tag[] | string[]) {
-    if ((typeof tags[0]) === 'string') {
+    if (!tags || tags.length === 0) {
+      this._tags = [];
+    } else if ((typeof tags[0]) === 'string') {
       this._tags = this.stringToTagObject(<string[]>tags); // happens only in tag tray
     } else {
       this._tags = <Tag[]>tags; // happens in details & meta view
@@ -28,9 +31,11 @@ export class ViewTagsComponent {
   @Input() darkMode: boolean;
   @Input() displayFrequency: boolean;
   @Input() draggable: boolean;
+  @Input() enableColorPicker: boolean = false;
 
   @Output() removeTagEmit = new EventEmitter<string>();
   @Output() tagClicked = new EventEmitter<TagEmit>();
+  @Output() tagRightClick = new EventEmitter<{ tag: Tag, event: MouseEvent }>();
 
   @ViewChild('dragHack', { static: false }) dragHack: ElementRef;
 
@@ -61,7 +66,7 @@ export class ViewTagsComponent {
     tagList.forEach((tag) => {
       hackList.push({
         name: tag,
-        colour: undefined,
+        colour: this.tagService.getTagColor(tag),
         removable: false,
       });
     });
@@ -81,6 +86,58 @@ export class ViewTagsComponent {
     quickHack.innerHTML = (event.target as HTMLElement).innerText;
 
     event.dataTransfer.setDragImage(quickHack, event.offsetX * 1.5, 21);
+  }
+
+  /**
+   * Handle right-click on tag - emit to parent to handle color picker
+   * @param event - MouseEvent
+   * @param tag - Tag
+   */
+  onTagRightClick(event: MouseEvent, tag: Tag): void {
+    if (!this.enableColorPicker) {
+      return;
+    }
+
+    // Only allow color picking for manual (removable) tags
+    if (!tag.removable) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    // Emit to parent component to handle color picker
+    this.tagRightClick.emit({ tag, event });
+  }
+
+  /**
+   * Calculate contrast color (white or black) based on background color luminance
+   * @param hexColor - Hex color code (e.g., '#FF6B6B')
+   * @returns 'white' or 'black' for optimal contrast
+   */
+  getContrastColor(hexColor: string): string {
+    if (!hexColor) {
+      return 'black';
+    }
+
+    // Remove # if present
+    const hex = hexColor.replace('#', '');
+
+    // Validate hex format (must be 6 characters)
+    if (hex.length !== 6 || !/^[0-9A-Fa-f]{6}$/.test(hex)) {
+      return 'black';
+    }
+
+    // Convert to RGB
+    const r = parseInt(hex.substring(0, 2), 16);
+    const g = parseInt(hex.substring(2, 4), 16);
+    const b = parseInt(hex.substring(4, 6), 16);
+
+    // Calculate relative luminance using WCAG formula
+    const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+
+    // Return white for dark backgrounds, black for light backgrounds
+    return luminance > 0.5 ? 'black' : 'white';
   }
 
 }

--- a/src/app/components/views/details/details.component.scss
+++ b/src/app/components/views/details/details.component.scss
@@ -2,7 +2,7 @@
   display: inline-block;
   margin: 20px 20px 0;
   min-height: 180px;
-  overflow: hidden;
+  overflow: visible; // changed from hidden to allow color picker to show
   transition: 300ms;
   transition-property: height;
 }


### PR DESCRIPTION
<!-- 🙇‍♂️ Thank you very much for contributing to VHA ♥ -->

Related issue: #{{887}}

# Add Custom Color Coding for Manual Tags

Fixes #887

## Overview
This PR adds the ability to assign custom colors to manual tags, making it easier to visually organize and identify tags throughout the application.

## Features

### Color Selection
- **Right-click context menu** on any manual tag to open a color picker
- **9 predefined colors** in a 3×3 grid for quick selection
- **"Reset to Default"** button to remove custom color and revert to the default blue
- Color picker works in both:
  - **Tag Tray** (top section showing all tags)
  - **Details View** (bottom drawer with video metadata)

### Visual Improvements
- **Automatic text contrast**: Tag text automatically switches between white and black based on background color luminance (WCAG formula)
- **Persistent colors**: Custom colors are saved in the `.vha2` file and persist across sessions
- **Consistent display**: Colors appear everywhere tags are shown (gallery views, details drawer, tag tray)

### User Experience
- Color picker uses `position: fixed` and renders at the root level to avoid clipping issues
- Picker automatically adjusts position to stay within viewport bounds
- Smooth overlay with semi-transparent background
- Immediate visual feedback when color is applied

### SCREENSHOTS
<img width="1890" height="1015" alt="image" src="https://github.com/user-attachments/assets/df6cf4ef-4100-4fa1-8516-52e0d52f152a" />
<img width="922" height="299" alt="image" src="https://github.com/user-attachments/assets/1142881e-c707-4f46-9e14-577e32e5d993" />
<img width="1626" height="983" alt="image" src="https://github.com/user-attachments/assets/a439a656-39fd-40da-ad41-e54a2c55e6b9" />


## Technical Implementation

### Architecture
- Created new `TagColorPickerComponent` with 3×3 color grid
- Used **RxJS Subjects** for cross-component communication via `ManualTagsService`
- Rendered color picker at **home component level** (outside scrolling containers) to prevent CSS clipping
- Components emit events to service → service notifies home component → picker renders at root level

### Key Components Modified
- **`TagColorPickerComponent`**: New component for color selection UI
- **`ManualTagsService`**: Manages tag colors state and cross-component communication
- **`ViewTagsComponent`**: Emits right-click events to parent components
- **`MetaComponent`**: Handles tag color updates in details view
- **`TagTrayComponent`**: Handles tag color updates in tag tray
- **`HomeComponent`**: Renders color picker at root level and handles color selection
- **`TagDisplayPipe`**: Applies custom colors when rendering tags
