### PR TITLE
Fix: Add background to 'file not found' snackbar notification.

### DIFF
--- a/src/app/components/modal/modal.service.ts
+++ b/src/app/components/modal/modal.service.ts
@@ -56,6 +56,7 @@ export class ModalService {
   openSnackbar(errorMessage: string) {
     this.snack.open(errorMessage, '', {
       duration: 1500,
+      panelClass: ['custom-snackbar']
     });
   }
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -16,6 +16,26 @@ html, body {
   box-shadow: 0 10px 20px 10px rgba(0,0,0,0.1);
 }
 
+// Snackbar container styles (for Angular Material v14+)
+.mat-mdc-snack-bar-container,
+.custom-snackbar {
+  --mdc-snackbar-container-color: #{variables.$pretty-red};
+  --mat-snack-bar-button-color: white;
+
+  .mdc-snackbar__surface {
+    background: variables.$pretty-red !important;
+    border: 1px solid red;
+    border-radius: 15px;
+    padding: 10px 20px;
+  }
+
+  .mat-mdc-snack-bar-label {
+    color: white;
+    text-align: center;
+  }
+}
+
+// Legacy support for older Angular Material versions
 .mat-simple-snackbar {
   background: variables.$pretty-red;
   border: 1px solid red;


### PR DESCRIPTION
<!-- 🙇‍♂️ Thank you very much for contributing to VHA ♥ -->

Related issue: #913

<!-- please add any additional comments too -->

## Description
Fixes #913 - The "file not found" toaster notification now displays with a visible background instead of being transparent.

## Problem
When clicking on a video file that has been moved or deleted, the error notification appeared with a transparent background, making the text very difficult to read.

## Solution
- Updated `src/styles.scss` to include proper styling for Angular Material v20's MDC-based snackbar components (`.mat-mdc-snack-bar-container` and related classes)
- Added `panelClass: ['custom-snackbar']` configuration in `modal.service.ts` for better style targeting
- Maintained backward compatibility with legacy Angular Material class names

## Changes
- `src/styles.scss`: Added MDC snackbar styles with red background and white text
- `src/app/components/modal/modal.service.ts`: Added custom CSS class to snackbar configuration

## Testing
1. Open a video hub with existing videos
2. Move or delete a video file from its original location (outside the app)
3. Click on the moved/deleted video in the app
4. Verify the "File not found" snackbar now displays with a red background and white text

## Screenshots

### Before
<img width="437" height="90" alt="Screenshot 2025-10-25 at 17 05 22" src="https://github.com/user-attachments/assets/f9387596-6a56-4b1c-bef9-3e579380ea56" />


### After
<img width="437" height="90" alt="Screenshot 2025-10-25 at 17 05 55" src="https://github.com/user-attachments/assets/db6df82d-f9f9-41b1-b298-0e48be886768" />


## Notes
The snackbar now uses a red background (`$pretty-red` variable) with white text, border, and rounded corners, consistent with the app's existing error notification styling.