### PR TITLE
hold shift & ctrl when clicking thumbnail to set as default

### DIFF
--- a/src/app/components/home.component.ts
+++ b/src/app/components/home.component.ts
@@ -1125,6 +1125,16 @@ export class HomeComponent implements OnInit, AfterViewInit {
       return;
     }
 
+    // ctrl + shift => set thumbnail as favorite
+    if (eventObject.mouseEvent.ctrlKey === true && eventObject.mouseEvent.shiftKey) {
+      this.imageElementService.HandleEmission({
+        index: item.index,
+        defaultScreen: eventObject.thumbIndex as number
+      });
+
+      return;
+    }
+
     // ctrl/cmd + click for thumbnail sheet
     if (eventObject.mouseEvent.ctrlKey === true || eventObject.mouseEvent.metaKey) {
       this.openThumbnailSheet(item);

--- a/src/app/components/views/thumbnail/thumbnail.component.html
+++ b/src/app/components/views/thumbnail/thumbnail.component.html
@@ -149,7 +149,7 @@
       [ngClass]="{ 'dark-style': darkMode }"
     >{{ video.durationDisplay }}</span>
     <span
-      *ngIf="showMeta"
+      *ngIf="showMeta && video.resolution"
       class="rez"
       [ngClass]="{ 'dark-style': darkMode }"
     >{{ video.resolution }}</span>


### PR DESCRIPTION
Closes: #941

Holding `CTRL` and `SHIFT` when clicking on a thumbnail will set the hovered-over thumbnail as the default screenshot 🥳