### PR TITLE
fix and persist recently-played

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -462,6 +462,7 @@
     "hidingFrequency": "Hiding frequency",
     "loading": "Loading",
     "minimum": "minimum",
+    "showMore": "show more",
     "notes": "notes",
     "pleaseEnable": "Please enable at least one tag type to see the Word cloud",
     "selectAllButton": "Select all visible",

--- a/node/main-support.ts
+++ b/node/main-support.ts
@@ -561,6 +561,9 @@ export function insertTemporaryFields(imagesArray: ImageElement[]): ImageElement
  * Insert temporary fields but just for one file
  */
 export function insertTemporaryFieldsSingle(element: ImageElement): ImageElement {
+
+  if (!element.lastPlayed) element.lastPlayed = 0; // fix `.vha2` files created prior to v3.2.0
+
   // set resolution string & bucket
   const resolution: ResolutionMeta = labelVideo(element.width, element.height);
   element.durationDisplay = getDurationDisplay(element.duration);

--- a/src/app/components/home.component.html
+++ b/src/app/components/home.component.html
@@ -642,11 +642,11 @@
       </div>
 
       <!-- Recently opened -->
-      <app-recently-opened
+      <app-recently-opened-hubs
         (openFromHistory)="openFromHistory($event)"
         [settingsButtons]="settingsButtons"
         [vhaFileHistory]="vhaFileHistory"
-      ></app-recently-opened>
+      ></app-recently-opened-hubs>
 
     </div> <!-- closing the SIDEBAR -->
 

--- a/src/app/components/home.component.html
+++ b/src/app/components/home.component.html
@@ -1110,6 +1110,7 @@
 
     (handleClick)="handleClick($event.expectedEvent, $event.item)"
     (rightMouseClicked)="rightMouseClicked($event.mouseEvent, $event.item)"
+    (showMoreRecentlyPlayed)="sortByRecentlyPlayed()"
 
     [appState]="appState"
     [currentClickedItemName]="currentClickedItemName"

--- a/src/app/components/home.component.ts
+++ b/src/app/components/home.component.ts
@@ -2225,7 +2225,15 @@ export class HomeComponent implements OnInit, AfterViewInit {
    * Sort by most-recent
    */
   sortByRecentlyPlayed(): void {
+    this.settingsButtons['sortOptionLastPlayed'].toggled = true;
+
     this.selectFilterOrder('lastPlayedDesc');
+
+    setTimeout(() => {
+      if (this.sortOrderRef.sortFilterElement) { // just in case, perform check
+        this.sortOrderRef.sortFilterElement.nativeElement.value = 'lastPlayedDesc';
+      }
+    });
   }
 
   /**

--- a/src/app/components/home.component.ts
+++ b/src/app/components/home.component.ts
@@ -2222,6 +2222,13 @@ export class HomeComponent implements OnInit, AfterViewInit {
   }
 
   /**
+   * Sort by most-recent
+   */
+  sortByRecentlyPlayed(): void {
+    this.selectFilterOrder('lastPlayedDesc');
+  }
+
+  /**
    * Check type-ahead for the manually-added tags!
    * @param text     input text to check type-ahead
    * @param compute  whether or not to perform the lookup

--- a/src/app/components/home.component.ts
+++ b/src/app/components/home.component.ts
@@ -728,7 +728,6 @@ export class HomeComponent implements OnInit, AfterViewInit {
       this.currentClickedItem = undefined;
       this.lastRenamedFileHack = undefined;
       this.imageElementService.finalArrayNeedsSaving = false;
-      this.imageElementService.recentlyPlayed = [];
 
       this.currentScreenshotSettings = finalObject.screenshotSettings;
 

--- a/src/app/components/recently-opened/recently-opened.component.ts
+++ b/src/app/components/recently-opened/recently-opened.component.ts
@@ -3,7 +3,7 @@ import type { SettingsButtonsType } from '../../common/settings-buttons';
 
 @Component({
   standalone: false,
-  selector: 'app-recently-opened',
+  selector: 'app-recently-opened-hubs',
   templateUrl: './recently-opened.component.html',
   styleUrls: ['./recently-opened.component.scss']
 })

--- a/src/app/components/similar-tray/similar-tray.component.html
+++ b/src/app/components/similar-tray/similar-tray.component.html
@@ -15,7 +15,8 @@
 
   <app-thumbnail
     *ngFor="let item of (showRecentNotSimilar
-                          ?  imageElementService.recentlyPlayed
+                          ? (imageElementService.imageElements | sortingPipe : 'lastPlayedDesc' : currentClickedItemName
+                                                               | slice : 0 : 8)
                           : (imageElementService.imageElements | similarityPipe : true : currentClickedItemName
                                                                | slice : 0 : 8 )
                         )"

--- a/src/app/components/similar-tray/similar-tray.component.html
+++ b/src/app/components/similar-tray/similar-tray.component.html
@@ -43,4 +43,15 @@
     style="display: inline-block; margin-bottom: 50px"
   ></app-thumbnail>
 
+  @if(showRecentNotSimilar) {
+    <div
+      (click)="showMoreRecentlyPlayed.emit()"
+      class="more"
+    >
+      <span>
+        {{ 'TAGS.showMore' | translate }}
+      </span>
+    </div>
+  }
+
 </div>

--- a/src/app/components/similar-tray/similar-tray.component.scss
+++ b/src/app/components/similar-tray/similar-tray.component.scss
@@ -18,3 +18,11 @@
     margin-top: 15px;
   }
 }
+
+.more {
+  position: absolute;
+  bottom: 6px;
+  right: 6px;
+  cursor: pointer;
+  font-size: 10px;
+}

--- a/src/app/components/similar-tray/similar-tray.component.ts
+++ b/src/app/components/similar-tray/similar-tray.component.ts
@@ -20,8 +20,9 @@ import { modalAnimation, similarResultsText } from '../../common/animations';
 })
 export class SimilarTrayComponent {
 
-  @Output() handleClick = new EventEmitter<any>(); // todo: fix up the vague type
+  @Output() handleClick = new EventEmitter<any>(); // TODO: fix up the vague type
   @Output() rightMouseClicked = new EventEmitter<RightClickEmit>();
+  @Output() showMoreRecentlyPlayed = new EventEmitter<any>();
 
   @Input() appState;
   @Input() currentClickedItemName;

--- a/src/app/pipes/sorting.pipe.ts
+++ b/src/app/pipes/sorting.pipe.ts
@@ -171,15 +171,11 @@ export class SortingPipe implements PipeTransform {
   transform(
     galleryArray: ImageElement[],
     sortingType: SortType,
-    forceSortUpdateHack: number,
+    forceSortUpdateHack: number | string, // changing input forces pipe to re-sort again
     skip: boolean
   ): ImageElement[] {
 
-    // console.log('SORTING RUNNING');
-    // console.log(sortingType);
-
     if (skip) {
-      // console.log('skipping !!!');
       return galleryArray;
     } else if (sortingType === 'random') {
 
@@ -252,11 +248,11 @@ export class SortingPipe implements PipeTransform {
       });
     } else if (sortingType === 'lastPlayedAsc') {
       return galleryArray.slice().sort((x: ImageElement, y: ImageElement): number => {
-        return this.sortFunctionLol(x, y, 'lastPlayed', false);
+        return this.sortFunctionLol(x, y, 'lastPlayed', true);
       });
     } else if (sortingType === 'lastPlayedDesc') {
       return galleryArray.slice().sort((x: ImageElement, y: ImageElement): number => {
-        return this.sortFunctionLol(x, y, 'lastPlayed', true);
+        return this.sortFunctionLol(x, y, 'lastPlayed', false);
       });
     } else if (sortingType === 'timesPlayedAsc') {
       return galleryArray.slice().sort((x: ImageElement, y: ImageElement): number => {

--- a/src/app/services/image-element.service.ts
+++ b/src/app/services/image-element.service.ts
@@ -12,7 +12,6 @@ export class ImageElementService {
 public finalArrayNeedsSaving = false;
 public forceStarFilterUpdate = true;
 public imageElements: ImageElement[] = [];
-public recentlyPlayed: ImageElement[] = [];
 
 constructor() { }
 
@@ -67,13 +66,12 @@ constructor() { }
    */
   updateNumberOfTimesPlayed(index: number) {
 
-    this.updateRecentlyPlayed(index);
+    this.imageElements[index].lastPlayed = Date.now(); // update `lastPlayed`
 
-    this.imageElements[index].lastPlayed = Date.now();
+    this.imageElements[index].timesPlayed
+      ? this.imageElements[index].timesPlayed++
+      : this.imageElements[index].timesPlayed = 1;     // update `timesPlayed`
 
-    this.imageElements[index].timesPlayed ?
-    this.imageElements[index].timesPlayed++ :
-    this.imageElements[index].timesPlayed = 1;
     this.finalArrayNeedsSaving = true;
   }
 
@@ -91,24 +89,6 @@ constructor() { }
         index: index,
         stars: 5.5
       });
-    }
-  }
-
-  /**
-   * Update recently played
-   *  - remove duplicates
-   *  - trim to at most 7
-   * @param index
-   */
-  updateRecentlyPlayed(index: number) {
-    this.recentlyPlayed = [
-      this.imageElements[index],
-      ...(this.recentlyPlayed.filter((element: ImageElement) => {
-        return element.hash !== this.imageElements[index].hash;
-      }))
-    ];
-    if (this.recentlyPlayed.length > 7) {
-      this.recentlyPlayed.length = 7;
     }
   }
 


### PR DESCRIPTION
Tray used to not show recently-played from previous time you opened the hub, now it does by re-using "last played" sort order.

PR fixes bug for all hubs created prior to `v.3.2.0` 😅  -- see #799 

I didn't account for hubs that didn't have `lastPlayed` key-value pair; having no key made the sorting function break - breaking sorting order 😔 

Closes #946 