### PR TITLE
output void when when output never passes data

### DIFF
--- a/src/app/components/rename-modal/rename-modal.component.ts
+++ b/src/app/components/rename-modal/rename-modal.component.ts
@@ -19,7 +19,7 @@ import type { SettingsButtonsType } from '../../common/settings-buttons';
 })
 export class RenameModalComponent {
 
-  readonly closeRename = output<any>();
+  readonly closeRename = output<void>();
 
   readonly appState = input<AppStateInterface>(undefined);
   readonly basePath = input<string>(undefined);

--- a/src/app/components/tag-tray/tag-tray.component.ts
+++ b/src/app/components/tag-tray/tag-tray.component.ts
@@ -22,9 +22,9 @@ import type { SettingsButtonsType } from '../../common/settings-buttons';
 })
 export class TagTrayComponent {
 
-  readonly toggleBatchTaggingMode = output<any>();
+  readonly toggleBatchTaggingMode = output<void>();
   readonly handleTagWordClicked = output<TagEmit>();
-  readonly selectAll = output<any>();
+  readonly selectAll = output<void>();
 
   readonly appState = input<AppStateInterface>(undefined);
   readonly batchTaggingMode = input(undefined);

--- a/src/app/components/title-bar/title-bar.component.ts
+++ b/src/app/components/title-bar/title-bar.component.ts
@@ -9,9 +9,9 @@ import type { SettingsButtonsType } from '../../common/settings-buttons';
 })
 export class TitleBarComponent {
 
-  readonly initiateClose = output<any>();
-  readonly initiateMaximize = output<any>();
-  readonly initiateMinimize = output<any>();
+  readonly initiateClose = output<void>();
+  readonly initiateMaximize = output<void>();
+  readonly initiateMinimize = output<void>();
 
   readonly appState = input(undefined);
   readonly demo = input<boolean>(undefined);

--- a/src/app/components/wizard/wizard.component.ts
+++ b/src/app/components/wizard/wizard.component.ts
@@ -24,12 +24,12 @@ export class WizardComponent {
 
   readonly clearRecentlyViewedHistory = output<any>();
   readonly hideWizard                 = output<any>();
-  readonly importFresh                = output<any>();
-  readonly loadFromFile               = output<any>();
+  readonly importFresh                = output<void>();
+  readonly loadFromFile               = output<void>();
   readonly openFromHistory            = output<number>();
   readonly removeFromHistory          = output<number>();
-  readonly selectOutputDirectory      = output<any>();
-  readonly selectSourceDirectory      = output<any>();
+  readonly selectOutputDirectory      = output<void>();
+  readonly selectSourceDirectory      = output<void>();
 
   readonly canCloseWizard = input<boolean>(undefined);
   readonly importStage = input<ImportStage>(undefined);


### PR DESCRIPTION
Code before this change was causing build errors like:

```
Error: src/app/components/wizard/wizard.component.html:403:28 - error TS2554: Expected 1 arguments, but got 0.

    (click)="importFresh.emit()"
```