### PR TITLE
Thumbnail component uses img element, not background-image

### DIFF
--- a/src/app/components/gallery.scss
+++ b/src/app/components/gallery.scss
@@ -40,16 +40,18 @@
 
 .title {
   -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  display: -webkit-box;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  // above all needed together for line-clamp
+
   color: variables.$gray-70;
   cursor: pointer;
-  display: -webkit-box;
   font-size: 12px;
-  -webkit-line-clamp: 3;
   margin: 6px 2px 0px;
   max-height: 54px;
-  overflow: hidden;
   text-align: left;
-  text-overflow: ellipsis;
   width: 100%;
   word-wrap: break-word;
 }

--- a/src/app/components/home.component.html
+++ b/src/app/components/home.component.html
@@ -1219,9 +1219,9 @@
   || settingsButtons['showRecentlyPlayed'].toggled) {
   <app-similar-tray
     (handleClick)="handleClick($event.expectedEvent, $event.item)"
+    (openDetailsView)="this.openThumbnailSheet($event)"
     (rightMouseClicked)="rightMouseClicked($event.mouseEvent, $event.item)"
     (showMoreRecentlyPlayed)="sortByRecentlyPlayed()"
-    (openDetailsView)="this.openThumbnailSheet($event)"
 
     [appState]="appState"
     [currentClickedItemName]="currentClickedItemName"

--- a/src/app/components/home.component.html
+++ b/src/app/components/home.component.html
@@ -1137,7 +1137,10 @@
 
 </div> <!-- end of window -->
 
-<!-- BOTTOM TRAY SECTION -->
+<!-- ===========    Bottom Tray Section    =========== -->
+
+<!-- -----------       five tabs     ----------------- -->
+
 <div
   class="all-settings-tabs bottom-tray-tabs"
   [ngClass]="{
@@ -1195,7 +1198,9 @@
 }
 </div>
 
-  <!-- ===========    Bottom Tray Section - region below tabs   =========== -->
+<!-- -----------       bottom tray contents     ----------------- -->
+
+<!-- bottom tray container & close button -->
 
 @if (settingsButtons['showDetailsTray'].toggled
   || settingsButtons['showFreq'].toggled
@@ -1214,7 +1219,8 @@
   >
     <app-icon class="close-modal-icon" [icon]="'icon-close'" />
   </div>
-  <!-- MOST SIMILAR & RECENTLY PLAYED -->
+
+<!-- SIMILAR & RECENT -- similar to last clicked, and list of recently played -->
 @if (settingsButtons['showRelatedVideosTray'].toggled
   || settingsButtons['showRecentlyPlayed'].toggled) {
   <app-similar-tray
@@ -1231,7 +1237,8 @@
     [showRecentNotSimilar]="settingsButtons['showRecentlyPlayed'].toggled"
    />
 }
-  <!-- TAGS -->
+
+<!-- TAGS -->
 @if (settingsButtons['showTagTray'].toggled) {
   <app-tag-tray
     (handleTagWordClicked)="handleTagWordClicked($event.tag.name, $event.event)"
@@ -1244,7 +1251,8 @@
     [updateTotalSelectedTrigger]="tagBatchModeSelectionChangedTrigger"
    />
 }
-  <!-- WORD CLOUD -->
+
+<!-- WORD CLOUD -->
 @if (settingsButtons['showFreq'].toggled) {
   <div
     class="cloud-frequency"
@@ -1276,7 +1284,8 @@
   }
   </div>
 }
-  <!-- RECENT -- that is current (last-clicked) file -->
+
+<!-- DETAILS -- for the last-clicked file -->
 @if (settingsButtons['showDetailsTray'].toggled) {
   <div
     class="current-clicked"
@@ -1332,8 +1341,9 @@
     }
   </div>
 }
+
 </div>
-}   <!-- end of bottom tray section (just below all the tabs)    =========== -->
+}   <!-- end of bottom tray section (just below all the tabs) -->
 
 <!-- WIZARD -->
 @if (wizard.showWizard) {

--- a/src/app/components/home.component.html
+++ b/src/app/components/home.component.html
@@ -1221,6 +1221,8 @@
     (handleClick)="handleClick($event.expectedEvent, $event.item)"
     (rightMouseClicked)="rightMouseClicked($event.mouseEvent, $event.item)"
     (showMoreRecentlyPlayed)="sortByRecentlyPlayed()"
+    (openDetailsView)="this.openThumbnailSheet($event)"
+
     [appState]="appState"
     [currentClickedItemName]="currentClickedItemName"
     [previewHeightRelated]="previewHeightRelated"
@@ -1274,7 +1276,7 @@
   }
   </div>
 }
-  <!-- CURRENT (last-clicked) FILE -->
+  <!-- RECENT -- that is current (last-clicked) file -->
 @if (settingsButtons['showDetailsTray'].toggled) {
   <div
     class="current-clicked"

--- a/src/app/components/meta/meta.component.html
+++ b/src/app/components/meta/meta.component.html
@@ -1,5 +1,5 @@
 <div
-  class="meta"
+  class="meta-container"
   [ngStyle]="{
     'min-height': imgHeight() + 'px',
     'width': maxWidth() + 'px'
@@ -26,7 +26,7 @@
 
 @if (renamingWIP === video.cleanName) {
   <span
-    class="file-size"
+    class="metadata-text"
     [ngClass]="{ darkModeText: darkMode() }"
   >
 
@@ -69,14 +69,14 @@
 
   @if (!renameError) {
     <span
-      class="file-size renaming-message"
+      class="metadata-text renaming-message"
       [ngClass]="{ 'renaming-message-dark-mode': darkMode() }"
     >
       {{ 'SYSTEM.pressEscToStopRenaming' | translate }}
     </span>
   } @else {
     <span
-      class="file-size renaming-message renaming-error"
+      class="metadata-text renaming-message renaming-error"
       [ngClass]="{ 'renaming-error-dark-mode': darkMode() }"
     >
       {{ 'SYSTEM.fileRenameError' | translate }}
@@ -131,7 +131,7 @@
 
 <!-- Times played -->
 @if (video.timesPlayed) {
-  <span class="file-size times-played" [ngStyle]="{color: darkMode() ? '#DDDDDD' : '#000000'}" >
+  <span class="metadata-text times-played" [ngStyle]="{color: darkMode() ? '#DDDDDD' : '#000000'}" >
     <em>{{ 'TAGS.timesPlayed' | translate }}:</em> {{ video.timesPlayed }}
   </span>
 }
@@ -139,13 +139,16 @@
 <!-- Add tags / view tags -->
 @if (showManualTags()) {
   <app-add-tag-component
+    style="display: block;"
     (tag)="addThisTag($event)"
     [darkMode]="darkMode()"
-    style="display: block;"
    />
 }
 
   <app-view-tags-component
+    class="view-tags-holder"
+    [ngStyle]="{ 'min-height': imgHeight() - 128 + 'px' }"
+
     [tags]="(video | tagDisplayPipe : showManualTags()
                                   : showAutoFileTags()
                                   : showAutoFolderTags()
@@ -153,19 +156,18 @@
                     | autoTagSortPipe : sortAutoTags"
     [darkMode]="darkMode()"
     [enableColorPicker]="true"
-    (tagClicked)="filterThisTag($event)"
+
     (removeTagEmit)="removeThisTag($event)"
+    (tagClicked)="filterThisTag($event)"
     (tagRightClick)="onTagRightClick($event)"
-    class="view-tags-holder"
-    [ngStyle]="{ 'min-height': imgHeight() - 128 + 'px' }"
    />
 
 @if (showVideoNotes()) {
   <textarea
     #videoNotes
+    [ngClass]="{ 'notes-dark-mode': darkMode() }"
     (blur)="saveVideoNotes($event)"
     placeholder="{{ 'TAGS.notes' | translate }}"
-    [ngClass]="{ 'notes-dark-mode': darkMode() }"
   >{{ video.notes }}</textarea>
 }
 

--- a/src/app/components/meta/meta.component.html
+++ b/src/app/components/meta/meta.component.html
@@ -12,7 +12,7 @@
     [ngClass]="{ 'larger-font': largerFont() }"
     [ngStyle]="{
         color: darkMode() ? '#DDDDDD' : '#000000',
-        width: renamingWIP.length + 2 + 'ch',
+        width: renamingWIP.length + 10 + 'ch',
         'max-width': maxWidth() - 20 + 'px'
       }"
     [(ngModel)]="renamingWIP"

--- a/src/app/components/meta/meta.component.scss
+++ b/src/app/components/meta/meta.component.scss
@@ -4,7 +4,7 @@
   color: variables.$gray-10;
 }
 
-.meta {
+.meta-container {
   box-sizing: border-box;
   display: inline-block;
   height: 190px;
@@ -13,33 +13,7 @@
   vertical-align: top;
 }
 
-.video-box {
-  background-color: black;
-  background-size: cover;
-  cursor: pointer;
-  display: inline-block;
-  overflow: hidden;
-  position: relative;
-}
-
-.title {
-  -webkit-box-orient: vertical;
-  display: -webkit-box;
-  font-size: 12px;
-  line-clamp: 3;
-  -webkit-line-clamp: 3;
-  max-height: 54px;
-  overflow: hidden;
-  text-align: left;
-  text-overflow: ellipsis;
-  transition: 300ms;
-  transition-property: font-size;
-  user-select: text;
-  width: 100%;
-  word-wrap: break-word;
-}
-
-.file-size {
+.metadata-text {
   display: block;
   font-family: monospace;
   font-size: 10px;

--- a/src/app/components/settings.scss
+++ b/src/app/components/settings.scss
@@ -176,12 +176,14 @@ h3 {
 
 .button-description-text {
   -webkit-box-orient: vertical !important;
-  color: variables.$black;
+  -webkit-line-clamp: 3 !important;
   display: -webkit-box !important;
+  overflow: hidden;
+  // above all needed together for line-clamp
+
+  color: variables.$black;
   font-size: 14px;
   left: 80px;
-  -webkit-line-clamp: 3 !important;
-  overflow: hidden;
   position: absolute;
   top: 2px;
 }

--- a/src/app/components/sheet/sheet.component.html
+++ b/src/app/components/sheet/sheet.component.html
@@ -70,15 +70,14 @@
         }"
       class="filmstrip-container"
     >
-      <div
-        class="video-box"
-        (click)="openVideoAtTime.emit({ mouseEvent: $event, thumbIndex: i })"
-        [ngStyle]="{
-            height: '100%',
-            'background-image': 'url(' + pathToFilmstripJpg + ')',
-            'background-position-x': (percentOffset * i) + '%'
-          }"
-      >
+      <div class="video-box">
+        <img
+          (click)="openVideoAtTime.emit({ mouseEvent: $event, thumbIndex: i })"
+          class="full-filmstrip"
+          [ngStyle]="{ height: '100%',
+                      transform: 'translate(' + (-percentOffset * i) + '%, 0)' }"
+          src="{{ pathToFilmstripJpg }}"
+        >
         <div
           class="set-favorite-thumb"
           (click)="setDefaultScreenshot($event, i)"

--- a/src/app/components/sheet/sheet.component.scss
+++ b/src/app/components/sheet/sheet.component.scss
@@ -68,6 +68,7 @@
   background-size: cover;
   border-radius: 6px;
   cursor: pointer;
+  height: 100%;
   overflow: hidden;
   position: relative;
 
@@ -78,6 +79,7 @@
   }
 
   .set-favorite-thumb {
+    cursor: cell;
     fill: yellow;
     height: 20px;
     opacity: 0;
@@ -86,6 +88,7 @@
     stroke-linejoin: round;
     stroke-width: 0.3px;
     stroke: #000000;
+    top: 0;
     width: 20px;
 
     &:hover {

--- a/src/app/components/sheet/sheet.component.ts
+++ b/src/app/components/sheet/sheet.component.ts
@@ -82,7 +82,7 @@ export class SheetComponent implements OnInit {
 
     this.pathToFilmstripJpg = this.filePathService.createFilePath(this.folderPath(), this.hubName(), 'filmstrips', this.video().hash);
     this.pathToVideoFile = path.join(this.selectedSourceFolder(), this.video().partialPath, this.video().fileName);
-    this.percentOffset = (100 / (this.video().screens - 1));
+    this.percentOffset = (100 / this.video().screens);
     this.starRatingHack = this.star();
   }
 

--- a/src/app/components/similar-tray/similar-tray.component.html
+++ b/src/app/components/similar-tray/similar-tray.component.html
@@ -16,9 +16,9 @@
 
 @for (item of (showRecentNotSimilar()
                ? (imageElementService.imageElements | sortingPipe : 'lastPlayedDesc' : currentClickedItemName()
-                                                    | slice : 0 : 8)
+                                                    | slice : 0 : 12)
                : (imageElementService.imageElements | similarityPipe : true : currentClickedItemName()
-                                                    | slice : 0 : 8 )
+                                                    | slice : 0 : 12)
               ); track item) {
 
   <app-thumbnail

--- a/src/app/components/similar-tray/similar-tray.component.html
+++ b/src/app/components/similar-tray/similar-tray.component.html
@@ -19,7 +19,7 @@
                                                     | slice : 0 : 12)
                : (imageElementService.imageElements | similarityPipe : true : currentClickedItemName()
                                                     | slice : 0 : 12)
-              ); track item) {
+              ); track item.uuid) {
 
   <app-thumbnail
     (videoClick)="handleClick.emit({ expectedEvent: $event, item: item })"

--- a/src/app/components/similar-tray/similar-tray.component.html
+++ b/src/app/components/similar-tray/similar-tray.component.html
@@ -24,6 +24,7 @@
   <app-thumbnail
     (videoClick)="handleClick.emit({ expectedEvent: $event, item: item })"
     (contextmenu)="rightMouseClicked.emit({ mouseEvent: $event, item: item })"
+    (sheetClick)="openDetailsView.emit(item)"
 
     [elHeight]="previewHeightRelated() + 50"
     [elWidth]="previewWidthRelated()"

--- a/src/app/components/similar-tray/similar-tray.component.scss
+++ b/src/app/components/similar-tray/similar-tray.component.scss
@@ -13,7 +13,13 @@
   }
 
   .most-similar-filename {
-    display: block;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 6;
+    display: -webkit-box;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    // above all needed together for line-clamp
+
     font-size: 14px;
     margin-top: 15px;
   }

--- a/src/app/components/similar-tray/similar-tray.component.ts
+++ b/src/app/components/similar-tray/similar-tray.component.ts
@@ -1,11 +1,12 @@
 import { Component, input, output } from '@angular/core';
 
 import { ImageElementService } from './../../services/image-element.service';
+import { modalAnimation, similarResultsText } from '../../common/animations';
 import { SourceFolderService } from '../statistics/source-folder.service';
 
+import type { ImageElement } from '../../../../interfaces/final-object.interface';
 import type { RightClickEmit } from '../../../../interfaces/shared-interfaces';
 import type { SettingsButtonsType } from '../../common/settings-buttons';
-import { modalAnimation, similarResultsText } from '../../common/animations';
 
 @Component({
   standalone: false,
@@ -23,6 +24,8 @@ export class SimilarTrayComponent {
   readonly handleClick = output<any>(); // TODO: fix up the vague type
   readonly rightMouseClicked = output<RightClickEmit>();
   readonly showMoreRecentlyPlayed = output<any>();
+
+  readonly openDetailsView = output<ImageElement>();
 
   readonly appState = input(undefined);
   readonly currentClickedItemName = input(undefined);

--- a/src/app/components/similar-tray/similar-tray.component.ts
+++ b/src/app/components/similar-tray/similar-tray.component.ts
@@ -1,8 +1,9 @@
 import { Component, input, output } from '@angular/core';
 
 import { ImageElementService } from './../../services/image-element.service';
-import { modalAnimation, similarResultsText } from '../../common/animations';
 import { SourceFolderService } from '../statistics/source-folder.service';
+
+import { modalAnimation, similarResultsText } from '../../common/animations';
 
 import type { ImageElement } from '../../../../interfaces/final-object.interface';
 import type { RightClickEmit } from '../../../../interfaces/shared-interfaces';
@@ -22,10 +23,9 @@ import type { SettingsButtonsType } from '../../common/settings-buttons';
 export class SimilarTrayComponent {
 
   readonly handleClick = output<any>(); // TODO: fix up the vague type
-  readonly rightMouseClicked = output<RightClickEmit>();
-  readonly showMoreRecentlyPlayed = output<any>();
-
   readonly openDetailsView = output<ImageElement>();
+  readonly rightMouseClicked = output<RightClickEmit>();
+  readonly showMoreRecentlyPlayed = output<void>();
 
   readonly appState = input(undefined);
   readonly currentClickedItemName = input(undefined);

--- a/src/app/components/views/clip-and-preview.scss
+++ b/src/app/components/views/clip-and-preview.scss
@@ -45,12 +45,6 @@
     transform: translate(-50%, -50%);
     width: 30%;
   }
-
-  &:hover {
-    + .sheet-icon {
-      opacity: 0.6;
-    }
-  }
 }
 
 .compact-margins {

--- a/src/app/components/views/clip-and-preview.scss
+++ b/src/app/components/views/clip-and-preview.scss
@@ -9,15 +9,17 @@
 
 .title {
   -webkit-box-orient: vertical;
-  display: -webkit-box;
-  font-size: 12px;
   -webkit-line-clamp: 3;
+  display: -webkit-box;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  // above all needed together for line-clamp
+
+  font-size: 12px;
   margin: 6px 2px 0px;
   max-height: 54px;
-  overflow: hidden;
   position: absolute;
   text-align: left;
-  text-overflow: ellipsis;
   transition: 300ms;
   transition-property: font-size;
   width: 100%;

--- a/src/app/components/views/clip/clip.component.html
+++ b/src/app/components/views/clip/clip.component.html
@@ -95,13 +95,14 @@
     @if (video.selected) { <app-icon class="selected" [icon]="'icon-show-more-info'" /> }
 
     @if (showMeta()) {
-      <span class="rez" [ngClass]="{ 'dark-style': darkMode() }">{{ video.fileSizeDisplay }}</span>
+      <span class="rez" [ngClass]="{ 'dark-style': darkMode() }">{{ video.fileSizeDisplay }}
+        @if (video.resolution) {
+          <span
+            class="time rez-new"
+          >{{ video.resolution }}</span>
+        }
+      </span>
 
-      @if (video.resolution) {
-        <span
-          class="time rez-new"
-        >{{ video.resolution }}</span>
-      }
 
       <span class="time" [ngClass]="{ 'dark-style': darkMode() }">{{ video.durationDisplay }}</span>
     }

--- a/src/app/components/views/clip/clip.component.html
+++ b/src/app/components/views/clip/clip.component.html
@@ -96,13 +96,8 @@
 
     @if (showMeta()) {
       <span class="rez" [ngClass]="{ 'dark-style': darkMode() }">{{ video.fileSizeDisplay }}
-        @if (video.resolution) {
-          <span
-            class="time rez-new"
-          >{{ video.resolution }}</span>
-        }
+        @if (video.resolution) { <span class="time rez-new">{{ video.resolution }}</span> }
       </span>
-
       <span class="time" [ngClass]="{ 'dark-style': darkMode() }">{{ video.durationDisplay }}</span>
     }
 
@@ -142,7 +137,6 @@
     ></video>
   }
 
-  @if (true) {
     <app-icon
       class="heart"
       [ngClass]="{ 'heart-lit' : video.stars === 5.5 }"
@@ -152,13 +146,8 @@
                                     : ('BUTTONS.addToFavorites' | translate) }}"
 
      />
-  }
 
-    <app-icon
-      class="sheet-icon"
-      [icon]="'icon-show-thumbnails'"
-      (click)="sheetClick.emit()"
-    />
+    <app-icon class="sheet-icon" [icon]="'icon-show-thumbnails'" (click)="sheetClick.emit()" />
 
   </div>
 

--- a/src/app/components/views/clip/clip.component.html
+++ b/src/app/components/views/clip/clip.component.html
@@ -103,7 +103,6 @@
         }
       </span>
 
-
       <span class="time" [ngClass]="{ 'dark-style': darkMode() }">{{ video.durationDisplay }}</span>
     }
 
@@ -155,18 +154,13 @@
      />
   }
 
-  </div> <!-- end of video-box -->
-  <!--
-  .sheet-icon needs to be the next sibling of .video-box
-  DO NOT SEPARATE!
-  -->
-  <app-icon
-    class="sheet-icon"
-    [icon]="'icon-show-thumbnails'"
-    (click)="sheetClick.emit()"
-    [ngStyle]="{
-      'opacity': (this.hover ? 1 : 0)
-    }" />
+    <app-icon
+      class="sheet-icon"
+      [icon]="'icon-show-thumbnails'"
+      (click)="sheetClick.emit()"
+    />
+
+  </div>
 
   <!-- ================================= TEXT ================================= -->
 

--- a/src/app/components/views/filmstrip/filmstrip.component.html
+++ b/src/app/components/views/filmstrip/filmstrip.component.html
@@ -19,10 +19,11 @@
   >
     @if (showMeta()) {
       <span class="time">{{ video().durationDisplay }}</span>
-      <span class="rez">{{ video().fileSizeDisplay }}</span>
-      @if (video().resolution) {
-        <span class="time rez-new">{{ video().resolution }}</span>
-      }
+      <span class="rez">{{ video().fileSizeDisplay }}
+        @if (video().resolution) {
+          <span class="time rez-new">{{ video().resolution }}</span>
+        }
+      </span>
     }
   </div>
 

--- a/src/app/components/views/thumbnail/thumbnail.component.html
+++ b/src/app/components/views/thumbnail/thumbnail.component.html
@@ -171,13 +171,15 @@
     <span
       class="rez"
       [ngClass]="{ 'dark-style': darkMode() }"
-    >{{ video.fileSizeDisplay }}</span>
+    >{{ video.fileSizeDisplay }}
 
     @if (video.resolution) {
       <span
         class="time rez-new"
       >{{ video.resolution }}</span>
     }
+  </span>
+
 
     <span
       class="time"

--- a/src/app/components/views/thumbnail/thumbnail.component.html
+++ b/src/app/components/views/thumbnail/thumbnail.component.html
@@ -139,7 +139,7 @@
       class="full-filmstrip"
       [ngStyle]="{ height: imgHeight() + 'px',
                   transform: 'translate(' + (-percentOffset) + '%, 0)' }"
-      src="{{ fullFilePath }}"
+      src="{{ hover ? fullFilePath : firstFilePath }}"
     >
 
   @if (video.selected) {

--- a/src/app/components/views/thumbnail/thumbnail.component.html
+++ b/src/app/components/views/thumbnail/thumbnail.component.html
@@ -161,7 +161,7 @@
       title="{{ 'BUTTONS.viewDetails' | translate }}"
       class="sheet-icon"
       [icon]="'icon-show-thumbnails'"
-      (click)="sheetClick.emit()"
+      (click)="openDetailsView()"
     />
 
     <div

--- a/src/app/components/views/thumbnail/thumbnail.component.html
+++ b/src/app/components/views/thumbnail/thumbnail.component.html
@@ -132,12 +132,15 @@
 
     (contextmenu)="rightClick.emit({ mouseEvent: $event, item: video })"
 
-    [ngStyle]="{
-        height: imgHeight() + 'px',
-        'background-image': 'url(' + (hover ? fullFilePath : firstFilePath) + ')',
-        'background-position-x': percentOffset + '%'
-      }"
+    [ngStyle]="{ height: imgHeight() + 'px' }"
   >
+
+    <img
+      class="full-filmstrip"
+      [ngStyle]="{ height: imgHeight() + 'px',
+                  transform: 'translate(' + (-percentOffset) + '%, 0)' }"
+      src="{{ fullFilePath }}"
+    >
 
   @if (video.selected) {
     <app-icon class="selected" [icon]="'icon-show-more-info'" />
@@ -151,40 +154,32 @@
       [icon]="'icon-heart'"
       title="{{ video.stars === 5.5 ? ('BUTTONS.removeFromFavorites' | translate)
                                     : ('BUTTONS.addToFavorites' | translate) }}"
-
      />
   }
 
-  <div
-    class="playlist-icon"
-    [ngClass]="{ 'playlist-icon-active' : video.playlist }"
-    (click)="togglePlaylist()"
-    title="{{ video.playlist ? ('BUTTONS.removeFromPlaylist' | translate)
-                             : ('BUTTONS.addToPlaylist' | translate) }}"
-  >
     <app-icon
-      [icon]="'icon-playlist'"
-      />
-  </div>
+      title="{{ 'BUTTONS.viewDetails' | translate }}"
+      class="sheet-icon"
+      [icon]="'icon-show-thumbnails'"
+      (click)="sheetClick.emit()"
+    />
+
+    <div
+      class="playlist-icon"
+      [ngClass]="{ 'playlist-icon-active' : video.playlist }"
+      (click)="togglePlaylist()"
+      title="{{ video.playlist ? ('BUTTONS.removeFromPlaylist' | translate)
+                              : ('BUTTONS.addToPlaylist' | translate) }}"
+    >
+      <app-icon [icon]="'icon-playlist'" />
+    </div>
 
   @if (showMeta()) {
-    <span
-      class="rez"
-      [ngClass]="{ 'dark-style': darkMode() }"
-    >{{ video.fileSizeDisplay }}
+    <span class="rez" [ngClass]="{ 'dark-style': darkMode() }">{{ video.fileSizeDisplay }}
+      @if (video.resolution) { <span class="time rez-new">{{ video.resolution }}</span>}
+    </span>
 
-    @if (video.resolution) {
-      <span
-        class="time rez-new"
-      >{{ video.resolution }}</span>
-    }
-  </span>
-
-
-    <span
-      class="time"
-      [ngClass]="{ 'dark-style': darkMode() }"
-    >{{ video.durationDisplay }}</span>
+    <span class="time" [ngClass]="{ 'dark-style': darkMode() }">{{ video.durationDisplay }}</span>
   }
 
   @if (!connected()) {
@@ -192,15 +187,7 @@
   }
 
   </div> <!-- end of (B) div --->
-  <!--
-  .sheet-icon needs to be the next sibling of .video-box aka `(B) div` for hover to work - SCSS rule
-  DO NOT SEPARATE!
-  -->
-  <app-icon
-    title="{{ 'BUTTONS.viewDetails' | translate }}"
-    class="sheet-icon"
-    [icon]="'icon-show-thumbnails'"
-    (click)="sheetClick.emit()" />
+
 
 @if (showMeta()) {
   <span

--- a/src/app/components/views/thumbnail/thumbnail.component.scss
+++ b/src/app/components/views/thumbnail/thumbnail.component.scss
@@ -42,6 +42,10 @@
   padding: 2px;
 }
 
+.full-filmstrip {
+  pointer-events: none;
+}
+
 .items-in-folder {
   font-size: 10px;
   left: 3px;

--- a/src/app/components/views/thumbnail/thumbnail.component.ts
+++ b/src/app/components/views/thumbnail/thumbnail.component.ts
@@ -27,7 +27,7 @@ export class ThumbnailComponent implements OnInit, OnDestroy {
 
   readonly refreshPlaylist = output<void>();
   readonly rightClick = output<RightClickEmit>();
-  readonly sheetClick = output<any>(); // does not emit data of any kind
+  readonly sheetClick = output<void>();
   readonly videoClick = output<VideoClickEmit>();
 
   @Input() video: ImageElement;
@@ -127,15 +127,20 @@ export class ThumbnailComponent implements OnInit, OnDestroy {
     clearInterval(this.scrollInterval);
   }
 
+  openDetailsView(): void {
+    event?.stopPropagation();
+    this.sheetClick.emit();
+  }
+
   toggleHeart(): void {
     this.imageElementService.toggleHeart(this.video.index);
-    event.stopPropagation();
+    event?.stopPropagation();
   }
 
   togglePlaylist(): void {
     this.imageElementService.updatePlaylist(this.video.index);
     this.refreshPlaylist.emit();
-    event.stopPropagation();
+    event?.stopPropagation();
   }
 
 }

--- a/src/app/components/views/thumbnail/thumbnail.component.ts
+++ b/src/app/components/views/thumbnail/thumbnail.component.ts
@@ -81,7 +81,7 @@ export class ThumbnailComponent implements OnInit, OnDestroy {
   }
 
   defaultScreenOffset(video: ImageElement): number {
-    return 100 * video.defaultScreen / (video.screens);
+    return 100 * video.defaultScreen / video.screens;
   }
 
   mouseEntered() {
@@ -91,7 +91,7 @@ export class ThumbnailComponent implements OnInit, OnDestroy {
       this.hover = true;
 
       this.scrollInterval = setInterval(() => {
-        this.percentOffset = this.indexToShow * (100 / (this.video.screens - 1));
+        this.percentOffset = this.indexToShow * (100 / this.video.screens);
         this.indexToShow++;
       }, 750);
 
@@ -119,7 +119,7 @@ export class ThumbnailComponent implements OnInit, OnDestroy {
     if (this.hoverScrub()) {
       const cursorX = $event.layerX;
       this.indexToShow = Math.floor(cursorX * (this.video.screens / this.containerWidth));
-      this.percentOffset = this.indexToShow * (100 / (this.video.screens));
+      this.percentOffset = this.indexToShow * (100 / this.video.screens);
     }
   }
 

--- a/src/app/components/views/thumbnail/thumbnail.component.ts
+++ b/src/app/components/views/thumbnail/thumbnail.component.ts
@@ -81,7 +81,7 @@ export class ThumbnailComponent implements OnInit, OnDestroy {
   }
 
   defaultScreenOffset(video: ImageElement): number {
-    return 100 * video.defaultScreen / (video.screens - 1);
+    return 100 * video.defaultScreen / (video.screens);
   }
 
   mouseEntered() {
@@ -119,7 +119,7 @@ export class ThumbnailComponent implements OnInit, OnDestroy {
     if (this.hoverScrub()) {
       const cursorX = $event.layerX;
       this.indexToShow = Math.floor(cursorX * (this.video.screens / this.containerWidth));
-      this.percentOffset = this.indexToShow * (100 / (this.video.screens - 1));
+      this.percentOffset = this.indexToShow * (100 / (this.video.screens));
     }
   }
 

--- a/src/app/components/views/time-and-rez.scss
+++ b/src/app/components/views/time-and-rez.scss
@@ -24,7 +24,8 @@
   background: none;
   border: none;
   color: white;
-  left: 37px;
+  left: 100%;
+  transform: translate(0, 2px);
   opacity: 0.6;
   right: unset;
 }

--- a/src/app/components/views/time-and-rez.scss
+++ b/src/app/components/views/time-and-rez.scss
@@ -83,10 +83,6 @@
   stroke: #ff2255;
 }
 
-.full-filmstrip {
-  pointer-events: none;
-}
-
 .meta-container,
 .video-box {
   .heart,

--- a/src/app/components/views/time-and-rez.scss
+++ b/src/app/components/views/time-and-rez.scss
@@ -83,9 +83,14 @@
   stroke: #ff2255;
 }
 
+.full-filmstrip {
+  pointer-events: none;
+}
+
 .meta-container,
 .video-box {
   .heart,
+  .sheet-icon,
   .playlist-icon {
     opacity: 0;
   }
@@ -97,6 +102,14 @@
   &:hover {
     .heart {
       opacity: 1;
+    }
+
+    .sheet-icon {
+      opacity: 0.6;
+
+      &:hover {
+        opacity: 1;
+      }
     }
 
     .playlist-icon {

--- a/src/app/services/image-element.service.ts
+++ b/src/app/services/image-element.service.ts
@@ -1,8 +1,9 @@
+import { Injectable } from '@angular/core';
+
+import type { DefaultScreenEmission, StarEmission } from '../components/sheet/sheet.component';
+import type { ImageElement } from './../../../interfaces/final-object.interface';
 import type { TagEmission } from './../../../interfaces/shared-interfaces';
 import type { YearEmission} from './../components/views/details/details.component';
-import type { ImageElement } from './../../../interfaces/final-object.interface';
-import { Injectable } from '@angular/core';
-import type { DefaultScreenEmission, StarEmission } from '../components/sheet/sheet.component';
 
 @Injectable({ providedIn: 'root' })
 export class ImageElementService {


### PR DESCRIPTION
Various small fixes and improvements 👍 ... and ... 🎉 

### Major bug fixed

With update to the latest Electron (because of how Chrome handles image rendering) `.video-box` `background-image` was not rendering sometimes at some background-position-x values. This meant hovering over a thumbnail would sometimes produce an empty box. This also happened in `app-thumbnail-sheet` where some thumbnails would not show up. Resizing the window would flicker some thumbnails into existence while hiding others.

One solution was to add `app.disableHardwareAcceleration()` right after importing `app` in `main.ts`

This disabled hardware acceleration, forcing the CPU to handle the image display -- fixing the problem.

But this was not great, so I opted to use `<img>` instead of the `background-image` CSS property ⚡ 

Seems to work beautifully 👨‍🍳 