### PR TITLE
prevent overwriting a hub with more than 50 videos when in demo mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Download Now
 
-This software is available for $5.00 through [videohubapp.com](https://videohubapp.com/en/download)
+This software is available for $10.00 through [videohubapp.com](https://videohubapp.com/en/download)
 
 $3.50 of every sale goes to the [_cost-effective_](https://www.givewell.org/charities/top-charities) charity [Against Malaria Foundation](https://www.againstmalaria.com/).
 

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -1,7 +1,7 @@
 {
   "productName": "Video Hub App 3",
   "appId": "com.videohubapp.videohubapp3",
-  "copyright": "Copyright © 2025 Boris Yakubchik",
+  "copyright": "Copyright © 2026 Boris Yakubchik",
   "directories": {
     "output": "release/"
   },

--- a/node/main-globals.ts
+++ b/node/main-globals.ts
@@ -4,8 +4,8 @@ import type { ScreenshotSettings, InputSources } from '../interfaces/final-objec
 //
 // `demo: true,`                 -- below
 // `version: 'X.X.X',`           -- below
-// `productName: "... Demo'`     -- package.json
 // `"version": "X.X.X",`         -- package.json
+// `"productName": "... Demo"    -- electron-builder.json
 
 export const GLOBALS: VhaGlobals = {
   angularApp: null,            // reference used to send messages back to Angular App

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "ip": "2.0.1",
         "natural-orderby": "5.0.0",
         "ng-qrcode": "22.0.0",
-        "object-hash": "^3.0.0",
+        "object-hash": "3.0.0",
         "path": "0.12.7",
         "trash": "7.2.0",
         "tslib": "2.8.1",

--- a/src/app/components/home.component.ts
+++ b/src/app/components/home.component.ts
@@ -1121,7 +1121,7 @@ export class HomeComponent implements OnInit, AfterViewInit {
   public getFinalObjectForSaving(): FinalObject {
 
     if (this.demo && this.demoSavingDisabled) {
-      this.modalService.openSnackbar("SAVING DISABLED - your hub has more than 50 videos", 5000);
+      this.modalService.openSnackbar("Previous hub changes not saved because hub has more than 50 videos", 3000);
       this.demoSavingDisabled = false;
       return null;
     }

--- a/src/app/components/home.component.ts
+++ b/src/app/components/home.component.ts
@@ -131,6 +131,7 @@ export class HomeComponent implements OnInit, AfterViewInit {
   appState = AppState;
 
   demo = GLOBALS.demo;
+  demoSavingDisabled = false;
   macVersion = GLOBALS.macVersion;
   versionNumber = GLOBALS.version;
 
@@ -755,6 +756,12 @@ export class HomeComponent implements OnInit, AfterViewInit {
 
       this.setTags(finalObject.addTags, finalObject.removeTags); // auto-tags
 
+      const currentVideos = finalObject.images.length;
+      if (this.demo && currentVideos > 50) {
+        this.modalService.openSnackbar("WARNING - your hub has more than 50 videos; saving disabled; please create a new hub", 5000);
+        this.demoSavingDisabled = true;
+      }
+
       this.imageElementService.imageElements = this.demo ? finalObject.images.slice(0, 50) : finalObject.images;
 
       this.canCloseWizard = true;
@@ -1112,6 +1119,14 @@ export class HomeComponent implements OnInit, AfterViewInit {
    * completely depends on global variable `finalArrayNeedsSaving` or if any tags were added/removed in auto-tag-service
    */
   public getFinalObjectForSaving(): FinalObject {
+
+    if (this.demo && this.demoSavingDisabled) {
+      this.modalService.openSnackbar("SAVING DISABLED - your hub has more than 50 videos", 5000);
+      this.demoSavingDisabled = false;
+      return null;
+    }
+
+
     if (this.imageElementService.finalArrayNeedsSaving || this.autoTagsSaveService.needToSave()) {
       const propsToReturn: FinalObject = {
         addTags: this.autoTagsSaveService.getAddTags(),

--- a/src/app/components/modal/modal.service.ts
+++ b/src/app/components/modal/modal.service.ts
@@ -53,9 +53,9 @@ export class ModalService {
    * Show "snack bar" / "toaster" at the bottom center with error message for 1.5 seconds
    * @param errorMessage
    */
-  openSnackbar(errorMessage: string) {
+  openSnackbar(errorMessage: string, duration = 1500) {
     this.snack.open(errorMessage, '', {
-      duration: 1500,
+      duration: duration,
       panelClass: ['custom-snackbar']
     });
   }


### PR DESCRIPTION
Demo mode possible catastrophe (*averted*):

Customer has version `3.2.0` with a hub of 1,000+ videos. They download the `3.3.0` _Demo_ and try it out. 

Without this PR / commit - the _Demo_ would open the customer's hub and `.slice(0, 50)` - removing all but 50 videos from the hub 😱 

Now we have `demoSavingDisabled` boolean which is set to _true_ if the original hub had more than 50 videos - which will prevent saving and overwriting the full hub 👍 